### PR TITLE
feat(client,sale): padroniza camelCase, regras de cliente e tratamento de unicidade

### DIFF
--- a/app/Application/Actions/Client/GuardClientCreditAction.php
+++ b/app/Application/Actions/Client/GuardClientCreditAction.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Client;
+
+use App\Domain\Enums\FinancialTransactionStatus;
+use App\Domain\Exceptions\ClientCreditLimitExceededException;
+use App\Domain\Models\Client;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Verifica se o cliente possui limite de crédito definido e se a nova venda
+ * ultrapassaria esse limite somando a exposição atual (contas a receber pendentes/em atraso).
+ *
+ * Regra: se credit_limit for null, nenhuma restrição é aplicada.
+ */
+final readonly class GuardClientCreditAction
+{
+    /**
+     * @throws ClientCreditLimitExceededException
+     */
+    public function execute(string $clientId, float $newSaleAmount): void
+    {
+        /** @var Client|null $client */
+        $client = Client::find($clientId);
+
+        if ($client === null || $client->credit_limit === null) {
+            return;
+        }
+
+        $creditLimit = (float) $client->credit_limit;
+
+        $currentExposure = (float) DB::table('financial_transactions')
+            ->join('sales', 'sales.id', '=', 'financial_transactions.reference_id')
+            ->where('sales.client_id', $clientId)
+            ->where('financial_transactions.reference_type', 'sale')
+            ->whereIn('financial_transactions.status', [
+                FinancialTransactionStatus::PENDING->value,
+                FinancialTransactionStatus::OVERDUE->value,
+            ])
+            ->whereNull('financial_transactions.deleted_at')
+            ->whereNull('sales.deleted_at')
+            ->sum('financial_transactions.amount');
+
+        if (($currentExposure + $newSaleAmount) > $creditLimit) {
+            throw new ClientCreditLimitExceededException(
+                clientId:        $clientId,
+                creditLimit:     $creditLimit,
+                currentExposure: $currentExposure,
+                newSaleAmount:   $newSaleAmount,
+            );
+        }
+    }
+}

--- a/app/Application/DTOs/ClientDTO.php
+++ b/app/Application/DTOs/ClientDTO.php
@@ -33,6 +33,8 @@ final readonly class ClientDTO
 
     /**
      * Constrói o DTO a partir de um model Eloquent Client.
+     *
+     * @param \App\Domain\Models\Client $client
      */
     public static function fromModel(\App\Domain\Models\Client $client): self
     {
@@ -77,10 +79,5 @@ final readonly class ClientDTO
             'createdAt'      => $this->createdAt,
             'updatedAt'      => $this->updatedAt,
         ];
-    }
-
-    public function isEmpty(): bool
-    {
-        return ($this->id === '' || $this->id === '0') && ($this->name === '' || $this->name === '0');
     }
 }

--- a/app/Application/DTOs/ClientDTO.php
+++ b/app/Application/DTOs/ClientDTO.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace App\Application\DTOs;
 
-class ClientDTO
+/**
+ * Representa os dados de um cliente na camada de saída (use case → controller → API).
+ * Construído a partir do model Eloquent Client após persistência.
+ */
+final readonly class ClientDTO
 {
     /**
      * @param array{name?: string|null}|null $company
@@ -12,12 +16,15 @@ class ClientDTO
     public function __construct(
         public string $id,
         public string $name,
-        public ?string $contact = null,
-        public ?string $phone = null,
-        public ?string $email = null,
         public ?string $personType = null,
         public ?string $documentNumber = null,
+        public ?string $email = null,
+        public ?string $phone = null,
+        public ?string $contact = null,
         public ?string $address = null,
+        public ?float $creditLimit = null,
+        public bool $isDefaulter = false,
+        public ?string $priceGroup = null,
         public ?array $company = null,
         public ?string $createdAt = null,
         public ?string $updatedAt = null,
@@ -25,24 +32,27 @@ class ClientDTO
     }
 
     /**
-     * @param array<string, mixed> $data
+     * Constrói o DTO a partir de um model Eloquent Client.
      */
-    public static function fromArray(array $data): self
+    public static function fromModel(\App\Domain\Models\Client $client): self
     {
         return new self(
-            id: $data['id'],
-            name: $data['name'],
-            contact: $data['contact'] ?? null,
-            phone: $data['phone'] ?? null,
-            email: $data['email'] ?? null,
-            personType: $data['person_type'] ?? null,
-            documentNumber: $data['document_number'] ?? null,
-            address: $data['address'] ?? null,
-            company: isset($data['company']) ? [
-                'name' => $data['company']['name'] ?? null,
+            id:             $client->id,
+            name:           $client->name,
+            personType:     $client->person_type,
+            documentNumber: $client->document_number,
+            email:          $client->email,
+            phone:          $client->phone,
+            contact:        $client->contact,
+            address:        $client->address,
+            creditLimit:    $client->credit_limit !== null ? (float) $client->credit_limit : null,
+            isDefaulter:    (bool) $client->is_defaulter,
+            priceGroup:     $client->price_group?->value,
+            company:        $client->relationLoaded('company') ? [
+                'name' => $client->company?->name,
             ] : null,
-            createdAt: $data['created_at'] ?? null,
-            updatedAt: $data['updated_at'] ?? null,
+            createdAt:      $client->created_at?->toDateTimeString(),
+            updatedAt:      $client->updated_at?->toDateTimeString(),
         );
     }
 
@@ -54,12 +64,15 @@ class ClientDTO
         return [
             'id'             => $this->id,
             'name'           => $this->name,
-            'contact'        => $this->contact,
-            'phone'          => $this->phone,
-            'email'          => $this->email,
             'personType'     => $this->personType,
             'documentNumber' => $this->documentNumber,
+            'email'          => $this->email,
+            'phone'          => $this->phone,
+            'contact'        => $this->contact,
             'address'        => $this->address,
+            'creditLimit'    => $this->creditLimit,
+            'isDefaulter'    => $this->isDefaulter,
+            'priceGroup'     => $this->priceGroup,
             'company'        => $this->company,
             'createdAt'      => $this->createdAt,
             'updatedAt'      => $this->updatedAt,

--- a/app/Application/DTOs/ClientInputDTO.php
+++ b/app/Application/DTOs/ClientInputDTO.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\DTOs;
+
+/**
+ * Carrega os dados de entrada para criação ou atualização de um cliente.
+ * Construído a partir do array validado pelo FormRequest e consumido pelo Repository.
+ */
+final readonly class ClientInputDTO
+{
+    public function __construct(
+        public string $companyId,
+        public string $name,
+        public string $personType,
+        public ?string $documentNumber = null,
+        public ?string $email = null,
+        public ?string $phone = null,
+        public ?string $contact = null,
+        public ?string $address = null,
+        public ?float $creditLimit = null,
+        public ?string $priceGroup = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            companyId:      (string) ($data['company_id'] ?? $data['companyId'] ?? ''),
+            name:           (string) ($data['name'] ?? ''),
+            personType:     (string) ($data['person_type'] ?? $data['personType'] ?? ''),
+            documentNumber: isset($data['document_number']) ? (string) $data['document_number']
+                          : (isset($data['documentNumber']) ? (string) $data['documentNumber'] : null),
+            email:          isset($data['email']) ? (string) $data['email'] : null,
+            phone:          isset($data['phone']) ? (string) $data['phone'] : null,
+            contact:        isset($data['contact']) ? (string) $data['contact'] : null,
+            address:        isset($data['address']) ? (string) $data['address'] : null,
+            creditLimit:    isset($data['credit_limit']) ? (float) $data['credit_limit']
+                          : (isset($data['creditLimit']) ? (float) $data['creditLimit'] : null),
+            priceGroup:     isset($data['price_group']) ? (string) $data['price_group']
+                          : (isset($data['priceGroup']) ? (string) $data['priceGroup'] : null),
+        );
+    }
+
+    /**
+     * Retorna os atributos prontos para persistência no banco.
+     *
+     * @return array<string, mixed>
+     */
+    public function toPersistence(): array
+    {
+        return [
+            'company_id'      => $this->companyId,
+            'name'            => $this->name,
+            'person_type'     => $this->personType,
+            'document_number' => $this->documentNumber,
+            'email'           => $this->email,
+            'phone'           => $this->phone,
+            'contact'         => $this->contact,
+            'address'         => $this->address,
+            'credit_limit'    => $this->creditLimit,
+            'price_group'     => $this->priceGroup,
+        ];
+    }
+}

--- a/app/Application/DTOs/HarvestSaleDTO.php
+++ b/app/Application/DTOs/HarvestSaleDTO.php
@@ -25,6 +25,7 @@ final readonly class HarvestSaleDTO
         public SaleStatus $status = SaleStatus::PENDING,
         public ?string $notes = null,
         public float $tolerancePercent = 5.0,
+        public bool $needsInvoice = false,
     ) {
     }
 
@@ -64,6 +65,7 @@ final readonly class HarvestSaleDTO
                                : SaleStatus::PENDING,
             notes:               isset($data['notes']) ? (string) $data['notes'] : null,
             tolerancePercent:    (float) ($data['tolerance_percent'] ?? $data['tolerancePercent'] ?? 5.0),
+            needsInvoice:        (bool) ($data['needs_invoice'] ?? $data['needsInvoice'] ?? false),
         );
     }
 

--- a/app/Application/UseCases/Batch/FinishBatchUseCase.php
+++ b/app/Application/UseCases/Batch/FinishBatchUseCase.php
@@ -44,7 +44,7 @@ class FinishBatchUseCase
             }
 
             if ($batch->status === 'finished') {
-                throw new Exception("Este lote já foi finalizado.");
+                throw new Exception("This batch has already been finished.");
             }
 
             $totalRevenue = $harvestData['total_weight'] * $harvestData['price_per_kg'];

--- a/app/Application/UseCases/Client/AnonymizeClientUseCase.php
+++ b/app/Application/UseCases/Client/AnonymizeClientUseCase.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace App\Application\UseCases\Client;
 
-use App\Domain\Exceptions\ClientHasPendingObligationsException;
 use App\Domain\Models\Client;
 use App\Domain\Repositories\ClientRepositoryInterface;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\DB;
 
-class DeleteClientUseCase
+/**
+ * Anonimiza os dados sensíveis do cliente (LGPD) e realiza o soft-delete.
+ *
+ * Preserva id e nome para manter o histórico financeiro da fazenda íntegro.
+ * Campos mascarados: email, phone, address, contact, document_number.
+ */
+class AnonymizeClientUseCase
 {
     public function __construct(
         protected ClientRepositoryInterface $clientRepository
@@ -20,15 +25,13 @@ class DeleteClientUseCase
     public function execute(string $id): void
     {
         DB::transaction(function () use ($id): void {
-            if ($this->clientRepository->hasPendingObligations($id)) {
-                throw new ClientHasPendingObligationsException($id);
-            }
+            $anonymized = $this->clientRepository->anonymize($id);
 
-            $deleted = $this->clientRepository->delete($id);
-
-            if (! $deleted) {
+            if (! $anonymized) {
                 throw (new ModelNotFoundException())->setModel(Client::class, $id);
             }
+
+            $this->clientRepository->delete($id);
         });
     }
 }

--- a/app/Application/UseCases/Client/CreateClientUseCase.php
+++ b/app/Application/UseCases/Client/CreateClientUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Application\UseCases\Client;
 
 use App\Application\DTOs\ClientDTO;
+use App\Application\DTOs\ClientInputDTO;
 use App\Domain\Repositories\ClientRepositoryInterface;
 use Illuminate\Support\Facades\DB;
 
@@ -20,24 +21,12 @@ class CreateClientUseCase
      */
     public function execute(array $data): ClientDTO
     {
-        return DB::transaction(function () use ($data): ClientDTO {
-            $client = $this->clientRepository->create($data);
+        $dto = ClientInputDTO::fromArray($data);
 
-            return new ClientDTO(
-                id: $client->id,
-                name: $client->name,
-                contact: $client->contact,
-                phone: $client->phone,
-                email: $client->email,
-                personType: $client->person_type,
-                documentNumber: $client->document_number,
-                address: $client->address,
-                company: [
-                    'name' => $client->company->name ?? null,
-                ],
-                createdAt: $client->created_at?->toDateTimeString(),
-                updatedAt: $client->updated_at?->toDateTimeString()
-            );
-        });
+        return DB::transaction(
+            fn (): ClientDTO => ClientDTO::fromModel(
+                $this->clientRepository->create($dto)
+            )
+        );
     }
 }

--- a/app/Application/UseCases/Client/ShowClientUseCase.php
+++ b/app/Application/UseCases/Client/ShowClientUseCase.php
@@ -7,7 +7,7 @@ namespace App\Application\UseCases\Client;
 use App\Application\DTOs\ClientDTO;
 use App\Domain\Models\Client;
 use App\Domain\Repositories\ClientRepositoryInterface;
-use RuntimeException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class ShowClientUseCase
 {
@@ -16,28 +16,14 @@ class ShowClientUseCase
     ) {
     }
 
-    public function execute(string $id): ?ClientDTO
+    public function execute(string $id): ClientDTO
     {
         $client = $this->clientRepository->showClient('id', $id);
 
         if (! $client instanceof Client) {
-            throw new RuntimeException('Client not found');
+            throw (new ModelNotFoundException())->setModel(Client::class, $id);
         }
 
-        return new ClientDTO(
-            id: $client->id,
-            name: $client->name,
-            contact: $client->contact,
-            phone: $client->phone,
-            email: $client->email,
-            personType: $client->person_type,
-            documentNumber: $client->document_number,
-            address: $client->address,
-            company: [
-                'name' => $client->company->name ?? null,
-            ],
-            createdAt: $client->created_at?->toDateTimeString(),
-            updatedAt: $client->updated_at?->toDateTimeString()
-        );
+        return ClientDTO::fromModel($client);
     }
 }

--- a/app/Application/UseCases/Client/UpdateClientUseCase.php
+++ b/app/Application/UseCases/Client/UpdateClientUseCase.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Application\UseCases\Client;
 
 use App\Application\DTOs\ClientDTO;
+use App\Domain\Exceptions\ClientDocumentAlreadyExistsException;
 use App\Domain\Models\Client;
 use App\Domain\Repositories\ClientRepositoryInterface;
-use RuntimeException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\QueryException;
 
 class UpdateClientUseCase
 {
@@ -21,26 +23,33 @@ class UpdateClientUseCase
      */
     public function execute(string $id, array $data): ClientDTO
     {
-        $client = $this->clientRepository->update($id, $data);
+        try {
+            $client = $this->clientRepository->update($id, $data);
+        } catch (QueryException $exception) {
+            if ($this->isClientDocumentUniqueViolation($exception)) {
+                throw new ClientDocumentAlreadyExistsException();
+            }
 
-        if (! $client instanceof Client) {
-            throw new RuntimeException('Client not found');
+            throw $exception;
         }
 
-        return new ClientDTO(
-            id: $client->id,
-            name: $client->name,
-            contact: $client->contact,
-            phone: $client->phone,
-            email: $client->email,
-            personType: $client->person_type,
-            documentNumber: $client->document_number,
-            address: $client->address,
-            company: [
-                'name' => $client->company->name ?? null,
-            ],
-            createdAt: $client->created_at?->toDateTimeString(),
-            updatedAt: $client->updated_at?->toDateTimeString()
-        );
+        if (! $client instanceof Client) {
+            throw (new ModelNotFoundException())->setModel(Client::class, $id);
+        }
+
+        return ClientDTO::fromModel($client);
+    }
+
+    private function isClientDocumentUniqueViolation(QueryException $exception): bool
+    {
+        $errorInfo = $exception->errorInfo;
+        $sqlState  = isset($errorInfo[0]) ? (string) $errorInfo[0] : '';
+        $driverMsg = isset($errorInfo[2]) ? (string) $errorInfo[2] : $exception->getMessage();
+
+        if ($sqlState !== '23000') {
+            return false;
+        }
+
+        return str_contains($driverMsg, 'clients_company_document_unique');
     }
 }

--- a/app/Application/UseCases/Sale/ProcessHarvestSaleUseCase.php
+++ b/app/Application/UseCases/Sale/ProcessHarvestSaleUseCase.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Application\UseCases\Sale;
 
+use App\Application\Actions\Client\GuardClientCreditAction;
 use App\Application\Actions\Sale\GenerateReceivableAction;
 use App\Application\Actions\Sale\GuardBiomassAction;
 use App\Application\Actions\Sale\RegisterBiomassOutflowAction;
 use App\Application\Contracts\CompanyResolverInterface;
 use App\Application\DTOs\HarvestSaleDTO;
+use App\Domain\Exceptions\ClientMissingFiscalDataException;
 use App\Domain\Exceptions\ClosedStockingException;
+use App\Domain\Models\Client;
 use App\Domain\Models\Sale;
 use App\Domain\Models\Stocking;
 use App\Domain\Repositories\SaleRepositoryInterface;
@@ -34,6 +37,7 @@ final readonly class ProcessHarvestSaleUseCase
         private GuardBiomassAction $guardBiomass,
         private RegisterBiomassOutflowAction $registerOutflow,
         private GenerateReceivableAction $generateReceivable,
+        private GuardClientCreditAction $guardClientCredit,
     ) {
     }
 
@@ -69,7 +73,13 @@ final readonly class ProcessHarvestSaleUseCase
             throw new ClosedStockingException($stocking->id);
         }
 
-        // Passo 1: Valida biomassa com tolerância configurável
+        // Passo 0: Valida dados fiscais se emissão de nota fiscal solicitada
+        $this->guardClientFiscalData($dto);
+
+        // Passo 1a: Valida limite de crédito do cliente
+        $this->guardClientCredit->execute($dto->clientId, $dto->totalRevenue());
+
+        // Passo 1b: Valida biomassa com tolerância configurável
         $this->guardBiomass->executeWithTolerance(
             stocking:         $stocking,
             requestedWeight:  $dto->totalWeight,
@@ -104,10 +114,36 @@ final readonly class ProcessHarvestSaleUseCase
      */
     private function processWithoutStocking(HarvestSaleDTO $dto): Sale
     {
+        $this->guardClientFiscalData($dto);
+        $this->guardClientCredit->execute($dto->clientId, $dto->totalRevenue());
+
         $sale = $this->repository->create($dto->toSaleInputDTO());
 
         $this->generateReceivable->execute($dto->toSaleInputDTO(), $sale);
 
         return $sale;
+    }
+
+    /**
+     * Se needs_invoice for true, exige que o cliente tenha document_number e address.
+     *
+     * @throws ClientMissingFiscalDataException
+     */
+    private function guardClientFiscalData(HarvestSaleDTO $dto): void
+    {
+        if (! $dto->needsInvoice) {
+            return;
+        }
+
+        /** @var Client|null $client */
+        $client = Client::find($dto->clientId);
+
+        if (
+            $client === null
+            || empty($client->document_number)
+            || empty($client->address)
+        ) {
+            throw new ClientMissingFiscalDataException($dto->clientId);
+        }
     }
 }

--- a/app/Console/Commands/MarkOverdueClientsCommand.php
+++ b/app/Console/Commands/MarkOverdueClientsCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Enums\FinancialTransactionStatus;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Sincroniza o campo is_defaulter dos clientes com base nas transações financeiras.
+ *
+ * Marcação como inadimplente: cliente com pelo menos uma FinancialTransaction
+ * com status = overdue vinculada via Sale.
+ *
+ * Remoção da flag: cliente sem nenhuma transação overdue em aberto.
+ *
+ * Agendamento sugerido: diário, via app/Console/Kernel ou schedule() no console.php.
+ */
+class MarkOverdueClientsCommand extends Command
+{
+    protected $signature = 'clients:mark-overdue
+                            {--dry-run : Exibe os clientes afetados sem persistir alterações}';
+
+    protected $description = 'Marca/desmarca clientes como inadimplentes com base em transações financeiras vencidas';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        $this->markDefaulters($dryRun);
+        $this->clearDefaulters($dryRun);
+
+        $this->info('Sincronização de inadimplência concluída.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Marca como inadimplentes os clientes que possuem transações overdue vinculadas.
+     */
+    private function markDefaulters(bool $dryRun): void
+    {
+        $clientIds = DB::table('financial_transactions')
+            ->join('sales', 'sales.id', '=', 'financial_transactions.reference_id')
+            ->where('financial_transactions.reference_type', 'sale')
+            ->where('financial_transactions.status', FinancialTransactionStatus::OVERDUE->value)
+            ->whereNull('financial_transactions.deleted_at')
+            ->whereNull('sales.deleted_at')
+            ->pluck('sales.client_id')
+            ->unique()
+            ->values()
+            ->all();
+
+        if (empty($clientIds)) {
+            $this->line('Nenhum cliente a marcar como inadimplente.');
+
+            return;
+        }
+
+        $this->line(sprintf('Marcando %d cliente(s) como inadimplente(s)...', count($clientIds)));
+
+        if (! $dryRun) {
+            DB::table('clients')
+                ->whereIn('id', $clientIds)
+                ->whereNull('deleted_at')
+                ->update(['is_defaulter' => true]);
+
+            Log::info('clients:mark-overdue — clientes marcados como inadimplentes', ['ids' => $clientIds]);
+        }
+    }
+
+    /**
+     * Remove a flag de inadimplência dos clientes que não possuem mais transações overdue.
+     */
+    private function clearDefaulters(bool $dryRun): void
+    {
+        $clientIdsWithOverdue = DB::table('financial_transactions')
+            ->join('sales', 'sales.id', '=', 'financial_transactions.reference_id')
+            ->where('financial_transactions.reference_type', 'sale')
+            ->where('financial_transactions.status', FinancialTransactionStatus::OVERDUE->value)
+            ->whereNull('financial_transactions.deleted_at')
+            ->whereNull('sales.deleted_at')
+            ->pluck('sales.client_id')
+            ->unique()
+            ->all();
+
+        $affected = DB::table('clients')
+            ->where('is_defaulter', true)
+            ->whereNull('deleted_at')
+            ->when(! empty($clientIdsWithOverdue), fn ($q) => $q->whereNotIn('id', $clientIdsWithOverdue))
+            ->pluck('id')
+            ->all();
+
+        if (empty($affected)) {
+            $this->line('Nenhum cliente a remover da inadimplência.');
+
+            return;
+        }
+
+        $this->line(sprintf('Removendo inadimplência de %d cliente(s)...', count($affected)));
+
+        if (! $dryRun) {
+            DB::table('clients')
+                ->whereIn('id', $affected)
+                ->update(['is_defaulter' => false]);
+
+            Log::info('clients:mark-overdue — clientes removidos da inadimplência', ['ids' => $affected]);
+        }
+    }
+}

--- a/app/Domain/Enums/PriceGroup.php
+++ b/app/Domain/Enums/PriceGroup.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Enums;
+
+enum PriceGroup: string
+{
+    case WHOLESALE = 'wholesale';
+    case RETAIL    = 'retail';
+    case CONSUMER  = 'consumer';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::WHOLESALE => 'Wholesale',
+            self::RETAIL    => 'Retail',
+            self::CONSUMER  => 'Consumer',
+        };
+    }
+}

--- a/app/Domain/Exceptions/ClientCreditLimitExceededException.php
+++ b/app/Domain/Exceptions/ClientCreditLimitExceededException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use RuntimeException;
+
+final class ClientCreditLimitExceededException extends RuntimeException
+{
+    public function __construct(string $clientId, float $creditLimit, float $currentExposure, float $newSaleAmount)
+    {
+        $total = $currentExposure + $newSaleAmount;
+
+        parent::__construct(
+            "The client (id: {$clientId}) has exceeded the credit limit. "
+            . "Limit: R$ {$creditLimit} | Current exposure:"
+            . "R$ {$currentExposure} | New sale: R$ {$newSaleAmount} | Total: R$ {$total}."
+        );
+    }
+}

--- a/app/Domain/Exceptions/ClientDocumentAlreadyExistsException.php
+++ b/app/Domain/Exceptions/ClientDocumentAlreadyExistsException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use RuntimeException;
+
+final class ClientDocumentAlreadyExistsException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'This CPF/CNPJ is already registered for this company.'
+        );
+    }
+}

--- a/app/Domain/Exceptions/ClientHasPendingObligationsException.php
+++ b/app/Domain/Exceptions/ClientHasPendingObligationsException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use RuntimeException;
+
+final class ClientHasPendingObligationsException extends RuntimeException
+{
+    public function __construct(string $clientId)
+    {
+        parent::__construct(
+            "The client (id: {$clientId}) has sales or receivables pending/overdue. "
+            . 'It is not possible to delete a client with outstanding financial obligations.'
+        );
+    }
+}

--- a/app/Domain/Exceptions/ClientMissingFiscalDataException.php
+++ b/app/Domain/Exceptions/ClientMissingFiscalDataException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use RuntimeException;
+
+final class ClientMissingFiscalDataException extends RuntimeException
+{
+    public function __construct(string $clientId)
+    {
+        parent::__construct(
+            "The client (id: {$clientId}) does not have CPF/CNPJ and/or address registered. "
+            . 'For invoice issuance, the document and address are required.'
+        );
+    }
+}

--- a/app/Domain/Models/Client.php
+++ b/app/Domain/Models/Client.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Domain\Models;
 
+use App\Domain\Enums\PriceGroup;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -13,12 +15,15 @@ use Illuminate\Support\Str;
  * @property string $id
  * @property string $company_id
  * @property string $name
+ * @property string $person_type
  * @property string|null $contact
  * @property string|null $phone
  * @property string|null $email
- * @property string|null $document_type
  * @property string|null $document_number
  * @property string|null $address
+ * @property float|null $credit_limit
+ * @property bool $is_defaulter
+ * @property PriceGroup|null $price_group
  * @property-read Company|null $company
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -42,6 +47,16 @@ class Client extends BaseModel
         'person_type',
         'document_number',
         'address',
+        'credit_limit',
+        'is_defaulter',
+        'price_group',
+    ];
+
+    /** @var array<string, string|class-string> */
+    protected $casts = [
+        'credit_limit' => 'decimal:2',
+        'is_defaulter' => 'boolean',
+        'price_group'  => PriceGroup::class,
     ];
 
     /** @var array<string> */
@@ -66,6 +81,17 @@ class Client extends BaseModel
     {
         /** @var BelongsTo<Company, static> $relation */
         $relation = $this->belongsTo(Company::class, 'company_id');
+
+        return $relation;
+    }
+
+    /**
+     * @phpstan-return HasMany<Sale, static>
+     */
+    public function sales(): HasMany
+    {
+        /** @var HasMany<Sale, static> $relation */
+        $relation = $this->hasMany(Sale::class, 'client_id');
 
         return $relation;
     }

--- a/app/Domain/Repositories/ClientRepositoryInterface.php
+++ b/app/Domain/Repositories/ClientRepositoryInterface.php
@@ -4,16 +4,15 @@ declare(strict_types=1);
 
 namespace App\Domain\Repositories;
 
+use App\Application\DTOs\ClientInputDTO;
 use App\Domain\Models\Client;
 
 interface ClientRepositoryInterface
 {
     /**
-     * Create a new financial transaction record.
-     *
-     * @param array<string, mixed> $data
+     * Persiste um novo cliente a partir do DTO de entrada.
      */
-    public function create(array $data): Client;
+    public function create(ClientInputDTO $dto): Client;
 
     /**
      * Update an existing financial transaction record.
@@ -36,4 +35,14 @@ interface ClientRepositoryInterface
      * Find a financial transaction by a specific field.
      */
     public function showClient(string $field, string | int $value): ?Client;
+
+    /**
+     * Verifica se o cliente possui vendas com transações financeiras pendentes ou em atraso.
+     */
+    public function hasPendingObligations(string $id): bool;
+
+    /**
+     * Anonimiza os dados sensíveis do cliente (LGPD), preservando id e nome.
+     */
+    public function anonymize(string $id): bool;
 }

--- a/app/Infrastructure/Persistence/ClientRepository.php
+++ b/app/Infrastructure/Persistence/ClientRepository.php
@@ -4,25 +4,29 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence;
 
+use App\Application\DTOs\ClientInputDTO;
+use App\Domain\Enums\FinancialTransactionStatus;
 use App\Domain\Models\Client;
 use App\Domain\Repositories\ClientRepositoryInterface;
 use App\Domain\Repositories\PaginationInterface;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\DB;
 
 class ClientRepository implements ClientRepositoryInterface
 {
     /**
-     * Create a new financial category.
-     *
-     * @param array<string, mixed> $data
+     * Persiste um novo cliente a partir do DTO de entrada.
      */
-    public function create(array $data): Client
+    public function create(ClientInputDTO $dto): Client
     {
-        return Client::create($data);
+        /** @var Client $client */
+        $client = Client::create($dto->toPersistence());
+
+        return $client->load('company');
     }
 
     /**
-     * Update an existing financial category.
+     * Atualiza um cliente e retorna o model atualizado com a relation company.
      *
      * @param array<string, mixed> $data
      */
@@ -30,13 +34,13 @@ class ClientRepository implements ClientRepositoryInterface
     {
         $client = Client::find($id);
 
-        if ($client) {
-            $client->update($data);
-
-            return $client;
+        if (! $client) {
+            return null;
         }
 
-        return null;
+        $client->update($data);
+
+        return $client->loadMissing('company:id,name');
     }
 
     /**
@@ -53,11 +57,11 @@ class ClientRepository implements ClientRepositoryInterface
     }
 
     /**
-     * Show financial category by field and value.
+     * Busca um cliente por campo/valor com a relation company carregada.
      */
     public function showClient(string $field, string | int $value): ?Client
     {
-        return Client::where($field, $value)->first();
+        return Client::with('company:id,name')->where($field, $value)->first();
     }
 
     /**
@@ -72,5 +76,45 @@ class ClientRepository implements ClientRepositoryInterface
         }
 
         return (bool) $client->delete();
+    }
+
+    /**
+     * Verifica se o cliente possui vendas com transações financeiras pendentes ou em atraso.
+     * O vínculo é: Client → Sales → FinancialTransactions (reference_type=sale, reference_id=sale.id).
+     */
+    public function hasPendingObligations(string $id): bool
+    {
+        return DB::table('financial_transactions')
+            ->join('sales', 'sales.id', '=', 'financial_transactions.reference_id')
+            ->where('sales.client_id', $id)
+            ->where('financial_transactions.reference_type', 'sale')
+            ->whereIn('financial_transactions.status', [
+                FinancialTransactionStatus::PENDING->value,
+                FinancialTransactionStatus::OVERDUE->value,
+            ])
+            ->whereNull('financial_transactions.deleted_at')
+            ->whereNull('sales.deleted_at')
+            ->exists();
+    }
+
+    /**
+     * Anonimiza os dados sensíveis do cliente (LGPD).
+     * Preserva id e nome para manter o histórico financeiro íntegro.
+     */
+    public function anonymize(string $id): bool
+    {
+        $client = Client::find($id);
+
+        if (! $client) {
+            return false;
+        }
+
+        $client->email           = null;
+        $client->phone           = null;
+        $client->address         = null;
+        $client->contact         = null;
+        $client->document_number = '[ANONIMIZADO]';
+
+        return $client->save();
     }
 }

--- a/app/Presentation/Controllers/ClientController.php
+++ b/app/Presentation/Controllers/ClientController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Presentation\Controllers;
 
-use App\Application\DTOs\ClientDTO;
+use App\Application\UseCases\Client\AnonymizeClientUseCase;
 use App\Application\UseCases\Client\CreateClientUseCase;
 use App\Application\UseCases\Client\DeleteClientUseCase;
 use App\Application\UseCases\Client\ListClientsUseCase;
@@ -15,7 +15,6 @@ use App\Presentation\Requests\Client\ClientUpdateRequest;
 use App\Presentation\Response\ApiResponse;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
-use Throwable;
 
 class ClientController
 {
@@ -25,43 +24,19 @@ class ClientController
      *     summary="List all clients",
      *     tags={"Clients"},
      *     security={{"bearerAuth":{}}},
-     *     @OA\Parameter(
-     *         name="page",
-     *         in="query",
-     *         description="Page number",
-     *         required=false,
-     *         @OA\Schema(type="integer", example=1)
-     *     ),
-     *     @OA\Parameter(
-     *         name="per_page",
-     *         in="query",
-     *         description="Items per page",
-     *         required=false,
-     *         @OA\Schema(type="integer", example=15)
-     *     ),
-     *     @OA\Response(
-     *         response=200,
-     *         description="List of clients",
-     *         @OA\JsonContent(
-     *             @OA\Property(property="success", type="boolean", example=true),
-     *             @OA\Property(property="message", type="string", example="Success"),
-     *             @OA\Property(property="data", type="array", @OA\Items(type="object"))
-     *         )
-     *     ),
+     *     @OA\Parameter(name="page", in="query", required=false, @OA\Schema(type="integer", example=1)),
+     *     @OA\Parameter(name="per_page", in="query", required=false, @OA\Schema(type="integer", example=15)),
+     *     @OA\Response(response=200, description="List of clients"),
      *     @OA\Response(response=401, description="Unauthorized")
      * )
      */
     public function index(ListClientsUseCase $useCase): JsonResponse
     {
-        try {
-            $clients    = $useCase->execute();
-            $data       = $clients->toArray(request());
-            $pagination = $clients->additional['pagination'] ?? null;
+        $clients    = $useCase->execute();
+        $data       = $clients->toArray(request());
+        $pagination = $clients->additional['pagination'] ?? null;
 
-            return ApiResponse::success($data, Response::HTTP_OK, 'Success', $pagination);
-        } catch (Throwable $exception) {
-            return ApiResponse::error($exception);
-        }
+        return ApiResponse::success($data, Response::HTTP_OK, 'Success', $pagination);
     }
 
     /**
@@ -70,43 +45,17 @@ class ClientController
      *     summary="Get a specific client",
      *     tags={"Clients"},
      *     security={{"bearerAuth":{}}},
-     *     @OA\Parameter(
-     *         name="id",
-     *         in="path",
-     *         description="Client ID",
-     *         required=true,
-     *         @OA\Schema(type="string", format="uuid")
-     *     ),
-     *     @OA\Response(
-     *         response=200,
-     *         description="Client details",
-     *         @OA\JsonContent(
-     *             @OA\Property(property="success", type="boolean", example=true),
-     *             @OA\Property(property="message", type="string", example="Success"),
-     *             @OA\Property(property="data", type="object")
-     *         )
-     *     ),
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(response=200, description="Client details"),
      *     @OA\Response(response=404, description="Client not found"),
      *     @OA\Response(response=401, description="Unauthorized")
      * )
      */
     public function show(string $id, ShowClientUseCase $useCase): JsonResponse
     {
-        try {
-            $client = $useCase->execute($id);
+        $client = $useCase->execute($id);
 
-            if (! $client instanceof ClientDTO || $client->isEmpty()) {
-                return ApiResponse::error(
-                    null,
-                    'Client not found',
-                    Response::HTTP_NOT_FOUND
-                );
-            }
-
-            return ApiResponse::success($client->toArray(), Response::HTTP_OK, 'Success');
-        } catch (Throwable $exception) {
-            return ApiResponse::error($exception, 'Client not found');
-        }
+        return ApiResponse::success($client->toArray(), Response::HTTP_OK, 'Success');
     }
 
     /**
@@ -118,80 +67,34 @@ class ClientController
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
-     *             required={"company_id", "name", "person_type"},
-     *             @OA\Property(
-     *                 property="company_id",
-     *                 type="string",
-     *                 format="uuid",
-     *                 example="550e8400-e29b-41d4-a716-446655440000"
-     *             ),
+     *             required={"companyId", "name", "personType"},
+     *             @OA\Property(property="companyId", type="string", format="uuid"),
      *             @OA\Property(property="name", type="string", maxLength=255, example="João Silva"),
+     *             @OA\Property(property="personType", type="string", enum={"individual", "company"}),
+     *             @OA\Property(property="documentNumber", type="string", nullable=true, example="12345678901"),
+     *             @OA\Property(property="email", type="string", format="email", nullable=true),
+     *             @OA\Property(property="phone", type="string", nullable=true, maxLength=20),
+     *             @OA\Property(property="contact", type="string", nullable=true, maxLength=255),
+     *             @OA\Property(property="address", type="string", nullable=true, maxLength=255),
+     *             @OA\Property(property="creditLimit", type="number", format="float", nullable=true),
      *             @OA\Property(
-     *                 property="contact",
+     *                 property="priceGroup",
      *                 type="string",
-     *                 nullable=true,
-     *                 maxLength=255,
-     *                 example="Maria Silva"
-     *             ),
-     *             @OA\Property(
-     *                 property="phone",
-     *                 type="string",
-     *                 nullable=true,
-     *                 maxLength=20,
-     *                 example="(85) 99999-9999"
-     *             ),
-     *             @OA\Property(
-     *                 property="email",
-     *                 type="string",
-     *                 format="email",
-     *                 nullable=true,
-     *                 maxLength=255,
-     *                 example="joao@example.com"
-     *             ),
-     *             @OA\Property(
-     *                 property="person_type",
-     *                 type="string",
-     *                 enum={"individual", "company"},
-     *                 example="individual"
-     *             ),
-     *             @OA\Property(
-     *                 property="document_number",
-     *                 type="string",
-     *                 nullable=true,
-     *                 pattern="^\\d{11}|\\d{14}$",
-     *                 example="12345678901"
-     *             ),
-     *             @OA\Property(
-     *                 property="address",
-     *                 type="string",
-     *                 nullable=true,
-     *                 maxLength=255,
-     *                 example="Rua Exemplo, 123"
+     *                 enum={"wholesale","retail","consumer"},
+     *                 nullable=true
      *             )
      *         )
      *     ),
-     *     @OA\Response(
-     *         response=201,
-     *         description="Client created successfully",
-     *         @OA\JsonContent(
-     *             @OA\Property(property="success", type="boolean", example=true),
-     *             @OA\Property(property="message", type="string", example="Client created successfully"),
-     *             @OA\Property(property="data", type="object")
-     *         )
-     *     ),
-     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=201, description="Client created successfully"),
+     *     @OA\Response(response=422, description="Validation error"),
      *     @OA\Response(response=401, description="Unauthorized")
      * )
      */
     public function store(ClientStoreRequest $request, CreateClientUseCase $useCase): JsonResponse
     {
-        try {
-            $client = $useCase->execute($request->validated());
+        $client = $useCase->execute($request->validated());
 
-            return ApiResponse::created($client->toArray());
-        } catch (Throwable $exception) {
-            return ApiResponse::error($exception, $exception->getMessage(), Response::HTTP_BAD_REQUEST);
-        }
+        return ApiResponse::created($client->toArray());
     }
 
     /**
@@ -200,129 +103,75 @@ class ClientController
      *     summary="Update a client",
      *     tags={"Clients"},
      *     security={{"bearerAuth":{}}},
-     *     @OA\Parameter(
-     *         name="id",
-     *         in="path",
-     *         description="Client ID",
-     *         required=true,
-     *         @OA\Schema(type="string", format="uuid")
-     *     ),
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
+     *             @OA\Property(property="name", type="string", maxLength=255),
+     *             @OA\Property(property="personType", type="string", enum={"individual", "company"}),
+     *             @OA\Property(property="documentNumber", type="string", nullable=true),
+     *             @OA\Property(property="email", type="string", format="email", nullable=true),
+     *             @OA\Property(property="phone", type="string", nullable=true),
+     *             @OA\Property(property="contact", type="string", nullable=true),
+     *             @OA\Property(property="address", type="string", nullable=true),
+     *             @OA\Property(property="creditLimit", type="number", format="float", nullable=true),
      *             @OA\Property(
-     *                 property="company_id",
+     *                 property="priceGroup",
      *                 type="string",
-     *                 format="uuid",
-     *                 example="550e8400-e29b-41d4-a716-446655440000"
-     *             ),
-     *             @OA\Property(property="name", type="string", maxLength=255, example="João Silva"),
-     *             @OA\Property(
-     *                 property="contact",
-     *                 type="string",
-     *                 nullable=true,
-     *                 maxLength=255,
-     *                 example="Maria Silva"
-     *             ),
-     *             @OA\Property(
-     *                 property="phone",
-     *                 type="string",
-     *                 nullable=true,
-     *                 maxLength=20,
-     *                 example="(85) 99999-9999"
-     *             ),
-     *             @OA\Property(
-     *                 property="email",
-     *                 type="string",
-     *                 format="email",
-     *                 nullable=true,
-     *                 maxLength=255,
-     *                 example="joao@example.com"
-     *             ),
-     *             @OA\Property(
-     *                 property="person_type",
-     *                 type="string",
-     *                 enum={"individual", "company"},
-     *                 example="individual"
-     *             ),
-     *             @OA\Property(
-     *                 property="document_number",
-     *                 type="string",
-     *                 nullable=true,
-     *                 pattern="^\\d{11}|\\d{14}$",
-     *                 example="12345678901"
-     *             ),
-     *             @OA\Property(
-     *                 property="address",
-     *                 type="string",
-     *                 nullable=true,
-     *                 maxLength=255,
-     *                 example="Rua Exemplo, 123"
+     *                 enum={"wholesale","retail","consumer"},
+     *                 nullable=true
      *             )
      *         )
      *     ),
-     *     @OA\Response(
-     *         response=200,
-     *         description="Client updated successfully",
-     *         @OA\JsonContent(
-     *             @OA\Property(property="success", type="boolean", example=true),
-     *             @OA\Property(property="message", type="string", example="Success"),
-     *             @OA\Property(property="data", type="object")
-     *         )
-     *     ),
-     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=200, description="Client updated successfully"),
+     *     @OA\Response(response=422, description="Validation error"),
      *     @OA\Response(response=404, description="Client not found"),
      *     @OA\Response(response=401, description="Unauthorized")
      * )
      */
     public function update(ClientUpdateRequest $request, string $id, UpdateClientUseCase $useCase): JsonResponse
     {
-        try {
-            $client = $useCase->execute($id, $request->validated());
+        $client = $useCase->execute($id, $request->validated());
 
-            return ApiResponse::success($client->toArray(), Response::HTTP_OK, 'Success');
-        } catch (Throwable $exception) {
-            return ApiResponse::error($exception, $exception->getMessage(), Response::HTTP_BAD_REQUEST);
-        }
+        return ApiResponse::success($client->toArray(), Response::HTTP_OK, 'Client updated successfully.');
     }
 
     /**
      * @OA\Delete(
      *     path="/company/client/{id}",
-     *     summary="Delete a client",
+     *     summary="Soft-delete a client",
      *     tags={"Clients"},
      *     security={{"bearerAuth":{}}},
-     *     @OA\Parameter(
-     *         name="id",
-     *         in="path",
-     *         description="Client ID",
-     *         required=true,
-     *         @OA\Schema(type="string", format="uuid")
-     *     ),
-     *     @OA\Response(
-     *         response=200,
-     *         description="Client deleted successfully",
-     *         @OA\JsonContent(
-     *             @OA\Property(property="success", type="boolean", example=true),
-     *             @OA\Property(property="message", type="string", example="Client successfully deleted")
-     *         )
-     *     ),
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(response=200, description="Client deleted successfully"),
+     *     @OA\Response(response=422, description="Client has pending obligations"),
      *     @OA\Response(response=404, description="Client not found"),
      *     @OA\Response(response=401, description="Unauthorized")
      * )
      */
     public function destroy(string $id, DeleteClientUseCase $useCase): JsonResponse
     {
-        try {
-            $deleted = $useCase->execute($id);
+        $useCase->execute($id);
 
-            if (! $deleted) {
-                return ApiResponse::error(null, 'Client not found', Response::HTTP_NOT_FOUND);
-            }
+        return ApiResponse::success(message: 'Client successfully deleted.');
+    }
 
-            return ApiResponse::success(null, Response::HTTP_OK, 'Client successfully deleted');
-        } catch (Throwable $exception) {
-            return ApiResponse::error($exception, 'Error deleting client');
-        }
+    /**
+     * @OA\Delete(
+     *     path="/company/client/{id}/anonymize",
+     *     summary="Anonymize and soft-delete a client (LGPD)",
+     *     tags={"Clients"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(response=200, description="Client anonymized and deleted"),
+     *     @OA\Response(response=404, description="Client not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
+    public function anonymize(string $id, AnonymizeClientUseCase $useCase): JsonResponse
+    {
+        $useCase->execute($id);
+
+        return ApiResponse::success(message: 'Client anonymized and deleted successfully.');
     }
 }

--- a/app/Presentation/Exceptions/Handler.php
+++ b/app/Presentation/Exceptions/Handler.php
@@ -7,6 +7,10 @@ namespace App\Presentation\Exceptions;
 use App\Application\Exceptions\CompanyNotFoundException;
 use App\Domain\Exceptions\AllocationAmountMismatchException;
 use App\Domain\Exceptions\CategoryTypeMismatchException;
+use App\Domain\Exceptions\ClientCreditLimitExceededException;
+use App\Domain\Exceptions\ClientDocumentAlreadyExistsException;
+use App\Domain\Exceptions\ClientHasPendingObligationsException;
+use App\Domain\Exceptions\ClientMissingFiscalDataException;
 use App\Domain\Exceptions\ClosedStockingException;
 use App\Domain\Exceptions\DuplicateStockException;
 use App\Domain\Exceptions\FinancialCategoryHasTransactionsException;
@@ -46,6 +50,11 @@ class Handler extends ExceptionHandler
         // Purchase
         CompanyNotFoundException::class,
         InvalidPurchaseStatusTransitionException::class,
+        // Client
+        ClientHasPendingObligationsException::class,
+        ClientMissingFiscalDataException::class,
+        ClientCreditLimitExceededException::class,
+        ClientDocumentAlreadyExistsException::class,
         // Stock
         DuplicateStockException::class,
         InsufficientStockException::class,
@@ -86,6 +95,34 @@ class Handler extends ExceptionHandler
             fn (UnauthorizedException $e, Request $r): JsonResponse => $this->handleDomainException(
                 $e,
                 JsonResponse::HTTP_UNAUTHORIZED,
+            )
+        );
+
+        // -----------------------------------------------------------------------
+        // Client
+        // -----------------------------------------------------------------------
+        $this->renderable(
+            fn (ClientHasPendingObligationsException $e, Request $r): JsonResponse => $this->handleDomainException(
+                $e,
+                JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+            )
+        );
+        $this->renderable(
+            fn (ClientMissingFiscalDataException $e, Request $r): JsonResponse => $this->handleDomainException(
+                $e,
+                JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+            )
+        );
+        $this->renderable(
+            fn (ClientCreditLimitExceededException $e, Request $r): JsonResponse => $this->handleDomainException(
+                $e,
+                JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+            )
+        );
+        $this->renderable(
+            fn (ClientDocumentAlreadyExistsException $e, Request $r): JsonResponse => $this->handleDomainException(
+                $e,
+                JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
             )
         );
 

--- a/app/Presentation/Requests/Client/ClientStoreRequest.php
+++ b/app/Presentation/Requests/Client/ClientStoreRequest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Presentation\Requests\Client;
 
+use App\Rules\DocumentNumberRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class ClientStoreRequest extends FormRequest
 {
@@ -14,7 +16,7 @@ class ClientStoreRequest extends FormRequest
     }
 
     /**
-     * @return array<string, array<int, \Illuminate\Contracts\Validation\ValidationRule|string>|string>
+     * @return array<string, array<int, \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\Rule|\Illuminate\Validation\Rules\Unique|string>|string>
      */
     public function rules(): array
     {
@@ -25,14 +27,31 @@ class ClientStoreRequest extends FormRequest
             'phone'           => ['nullable', 'string', 'max:20'],
             'email'           => ['nullable', 'email', 'max:255'],
             'person_type'     => ['required', 'string', 'in:individual,company'],
-            'document_number' => ['nullable', 'string', 'regex:/^\d{11}|\d{14}$/'],
-            'address'         => ['nullable', 'string', 'max:255'],
+            'document_number' => [
+                'nullable',
+                'string',
+                new DocumentNumberRule($this->input('person_type')),
+                Rule::unique('clients')->where('company_id', $this->input('company_id')),
+            ],
+            'address'      => ['nullable', 'string', 'max:255'],
+            'credit_limit' => ['nullable', 'numeric', 'min:0'],
+            'price_group'  => ['nullable', 'string', 'in:wholesale,retail,consumer'],
         ];
     }
 
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'company_id'      => $this->input('company_id', $this->input('companyId')),
+            'person_type'     => $this->input('person_type', $this->input('personType')),
+            'document_number' => $this->input('document_number', $this->input('documentNumber')),
+            'credit_limit'    => $this->input('credit_limit', $this->input('creditLimit')),
+            'price_group'     => $this->input('price_group', $this->input('priceGroup')),
+        ]);
+    }
+
     /**
-     * Get custom error messages for validation rules.
-     *
      * @return array<string, string>
      */
     #[\Override]
@@ -60,11 +79,16 @@ class ClientStoreRequest extends FormRequest
             'person_type.string'   => 'The person type must be a string.',
             'person_type.in'       => 'The person type must be either "individual" or "company".',
 
-            'document_number.string' => 'The document number must be a string.',
-            'document_number.regex'  => 'The document number must be either 11 (CPF) or 14 (CNPJ) digits.',
+            'document_number.unique' => 'This CPF/CNPJ is already registered for this company.',
 
             'address.string' => 'The address must be a string.',
             'address.max'    => 'The address may not be greater than 255 characters.',
+
+            'credit_limit.numeric' => 'The credit limit must be a numeric value.',
+            'credit_limit.min'     => 'The credit limit cannot be negative.',
+
+            'price_group.string' => 'The price group must be a string.',
+            'price_group.in'     => 'The price group must be: wholesale, retail or consumer.',
         ];
     }
 }

--- a/app/Presentation/Requests/Client/ClientUpdateRequest.php
+++ b/app/Presentation/Requests/Client/ClientUpdateRequest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Presentation\Requests\Client;
 
+use App\Rules\DocumentNumberRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class ClientUpdateRequest extends FormRequest
 {
@@ -14,10 +16,14 @@ class ClientUpdateRequest extends FormRequest
     }
 
     /**
-     * @return array<string, array<int, \Illuminate\Contracts\Validation\ValidationRule|string>|string>
+     * @return array<string, array<int, \Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Contracts\Validation\Rule|\Illuminate\Validation\Rules\Unique|string>|string>
      */
     public function rules(): array
     {
+        $clientId   = $this->route('client');
+        $companyId  = $this->input('company_id');
+        $personType = $this->input('person_type');
+
         return [
             'company_id'      => ['sometimes', 'uuid', 'exists:companies,id'],
             'name'            => ['sometimes', 'string', 'max:255'],
@@ -25,14 +31,33 @@ class ClientUpdateRequest extends FormRequest
             'phone'           => ['nullable', 'string', 'max:20'],
             'email'           => ['nullable', 'email', 'max:255'],
             'person_type'     => ['sometimes', 'string', 'in:individual,company'],
-            'document_number' => ['nullable', 'string', 'regex:/^\d{11}|\d{14}$/'],
-            'address'         => ['nullable', 'string', 'max:255'],
+            'document_number' => [
+                'nullable',
+                'string',
+                new DocumentNumberRule($personType),
+                Rule::unique('clients')
+                    ->where('company_id', $companyId)
+                    ->ignore($clientId),
+            ],
+            'address'      => ['nullable', 'string', 'max:255'],
+            'credit_limit' => ['nullable', 'numeric', 'min:0'],
+            'price_group'  => ['nullable', 'string', 'in:wholesale,retail,consumer'],
         ];
     }
 
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'company_id'      => $this->input('company_id', $this->input('companyId')),
+            'person_type'     => $this->input('person_type', $this->input('personType')),
+            'document_number' => $this->input('document_number', $this->input('documentNumber')),
+            'credit_limit'    => $this->input('credit_limit', $this->input('creditLimit')),
+            'price_group'     => $this->input('price_group', $this->input('priceGroup')),
+        ]);
+    }
+
     /**
-     * Get custom error messages for validation rules.
-     *
      * @return array<string, string>
      */
     #[\Override]
@@ -57,11 +82,16 @@ class ClientUpdateRequest extends FormRequest
             'person_type.string' => 'The person type must be a string.',
             'person_type.in'     => 'The person type must be either "individual" or "company".',
 
-            'document_number.string' => 'The document number must be a string.',
-            'document_number.regex'  => 'The document number must be either 11 (CPF) or 14 (CNPJ) digits.',
+            'document_number.unique' => 'Este CPF/CNPJ já está cadastrado para esta empresa.',
 
             'address.string' => 'The address must be a string.',
             'address.max'    => 'The address may not be greater than 255 characters.',
+
+            'credit_limit.numeric' => 'O limite de crédito deve ser um valor numérico.',
+            'credit_limit.min'     => 'O limite de crédito não pode ser negativo.',
+
+            'price_group.string' => 'O grupo de preço deve ser uma string.',
+            'price_group.in'     => 'O grupo de preço deve ser: wholesale, retail ou consumer.',
         ];
     }
 }

--- a/app/Presentation/Requests/Sale/SaleStoreRequest.php
+++ b/app/Presentation/Requests/Sale/SaleStoreRequest.php
@@ -33,6 +33,7 @@ class SaleStoreRequest extends FormRequest
             'notes'                 => ['nullable', 'string'],
             'is_total_harvest'      => ['nullable', 'boolean'],
             'tolerance_percent'     => ['nullable', 'numeric', 'min:0', 'max:50'],
+            'needs_invoice'         => ['nullable', 'boolean'],
         ];
     }
 
@@ -66,10 +67,32 @@ class SaleStoreRequest extends FormRequest
 
             'status.Illuminate\Validation\Rules\Enum' => 'The status must be: pending, confirmed or cancelled.',
 
+            'needs_invoice.boolean'     => 'The needs invoice field must be true or false.',
             'is_total_harvest.boolean'  => 'The total harvest field must be true or false.',
             'tolerance_percent.numeric' => 'The tolerance percent must be numeric.',
             'tolerance_percent.min'     => 'The tolerance percent must be greater than zero.',
             'tolerance_percent.max'     => 'The tolerance percent must be less than or equal to 50.',
         ];
+    }
+
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'company_id'            => $this->input('company_id', $this->input('companyId')),
+            'client_id'             => $this->input('client_id', $this->input('clientId')),
+            'batch_id'              => $this->input('batch_id', $this->input('batchId')),
+            'stocking_id'           => $this->input('stocking_id', $this->input('stockingId')),
+            'financial_category_id' => $this->input('financial_category_id', $this->input('financialCategoryId')),
+
+            'total_weight'      => $this->input('total_weight', $this->input('totalWeight')),
+            'price_per_kg'      => $this->input('price_per_kg', $this->input('pricePerKg')),
+            'sale_date'         => $this->input('sale_date', $this->input('saleDate')),
+            'status'            => $this->input('status'),
+            'notes'             => $this->input('notes'),
+            'is_total_harvest'  => $this->input('is_total_harvest', $this->input('isTotalHarvest')),
+            'tolerance_percent' => $this->input('tolerance_percent', $this->input('tolerancePercent')),
+            'needs_invoice'     => $this->input('needs_invoice', $this->input('needsInvoice')),
+        ]);
     }
 }

--- a/app/Presentation/Requests/Sale/SaleUpdateRequest.php
+++ b/app/Presentation/Requests/Sale/SaleUpdateRequest.php
@@ -44,4 +44,17 @@ class SaleUpdateRequest extends FormRequest
             'status.Illuminate\Validation\Rules\Enum' => 'The status must be: pending, confirmed or cancelled.',
         ];
     }
+
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'client_id'    => $this->input('client_id', $this->input('clientId')),
+            'total_weight' => $this->input('total_weight', $this->input('totalWeight')),
+            'price_per_kg' => $this->input('price_per_kg', $this->input('pricePerKg')),
+            'sale_date'    => $this->input('sale_date', $this->input('saleDate')),
+            'status'       => $this->input('status'),
+            'notes'        => $this->input('notes'),
+        ]);
+    }
 }

--- a/app/Presentation/Resources/Client/ClientResource.php
+++ b/app/Presentation/Resources/Client/ClientResource.php
@@ -17,6 +17,9 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @property-read string|null $email
  * @property-read string|null $phone
  * @property-read string|null $contact
+ * @property-read float|null $credit_limit
+ * @property-read bool $is_defaulter
+ * @property-read \App\Domain\Enums\PriceGroup|null $price_group
  * @property-read \Illuminate\Support\Carbon|null $created_at
  * @property-read \Illuminate\Support\Carbon|null $updated_at
  * @property-read \App\Domain\Models\Company|null $company
@@ -41,6 +44,9 @@ class ClientResource extends JsonResource
             'phone'          => $this->phone,
             'contact'        => $this->contact,
             'address'        => $this->address,
+            'creditLimit'    => $this->credit_limit,
+            'isDefaulter'    => (bool) $this->is_defaulter,
+            'priceGroup'     => $this->price_group?->value,
             'company'        => $this->whenLoaded('company', fn (): array => [
                 'name' => $this->company->name,
             ]),

--- a/app/Presentation/Resources/FinancialCategory/FinancialCategoryResource.php
+++ b/app/Presentation/Resources/FinancialCategory/FinancialCategoryResource.php
@@ -34,7 +34,6 @@ class FinancialCategoryResource extends JsonResource
             'status'      => $this->status->value,
             'statusLabel' => $this->status->label(),
             'company'     => $this->whenLoaded('company', fn (): array => [
-                'id'   => $this->company->id,
                 'name' => $this->company->name,
             ]),
             'createdAt' => $this->created_at?->toDateTimeString(),

--- a/app/Presentation/Resources/FinancialTransaction/FinancialTransactionResource.php
+++ b/app/Presentation/Resources/FinancialTransaction/FinancialTransactionResource.php
@@ -53,7 +53,6 @@ class FinancialTransactionResource extends JsonResource
             'referenceType' => $this->reference_type?->value,
             'referenceId'   => $this->reference_id,
             'company'       => $this->whenLoaded('company', fn (): array => [
-                'id'   => $this->company->id,
                 'name' => $this->company->name,
             ]),
             'category' => $this->whenLoaded('category', fn (): array => [

--- a/app/Presentation/Resources/Sale/SaleResource.php
+++ b/app/Presentation/Resources/Sale/SaleResource.php
@@ -50,7 +50,6 @@ class SaleResource extends JsonResource
             'batchId'      => $this->batch_id,
             'stockingId'   => $this->stocking_id,
             'company'      => $this->whenLoaded('company', fn (): array => [
-                'id'   => $this->company->id,
                 'name' => $this->company->name,
             ]),
             'client' => $this->whenLoaded('client', fn (): array => [

--- a/app/Rules/DocumentNumberRule.php
+++ b/app/Rules/DocumentNumberRule.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Valida que o document_number corresponde ao person_type:
+ *   - individual → CPF com exatamente 11 dígitos
+ *   - company    → CNPJ com exatamente 14 dígitos
+ *
+ * Aceita somente dígitos (sem pontuação).
+ */
+final class DocumentNumberRule implements ValidationRule
+{
+    public function __construct(private readonly ?string $personType)
+    {
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($value === null || $value === '') {
+            return;
+        }
+
+        $digits = preg_replace('/\D/', '', (string) $value);
+
+        if ($this->personType === 'individual') {
+            if ($digits === null || strlen($digits) !== 11) {
+                $fail('The :attribute must contain exactly 11 digits (CPF) for physical person.');
+            }
+
+            return;
+        }
+
+        if ($this->personType === 'company') {
+            if ($digits === null || strlen($digits) !== 14) {
+                $fail('The :attribute must contain exactly 14 digits (CNPJ) for legal person.');
+            }
+
+            return;
+        }
+
+        if ($digits === null || ! in_array(strlen($digits), [11, 14], strict: true)) {
+            $fail('The :attribute must contain 11 digits (CPF) or 14 digits (CNPJ).');
+        }
+    }
+}

--- a/database/migrations/2026_03_24_100000_add_uniqueness_credit_market_to_clients_table.php
+++ b/database/migrations/2026_03_24_100000_add_uniqueness_credit_market_to_clients_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clients', function (Blueprint $table): void {
+            $table->decimal('credit_limit', 10, 2)->nullable()->after('address');
+            $table->boolean('is_defaulter')->default(false)->after('credit_limit');
+            $table->enum('price_group', ['wholesale', 'retail', 'consumer'])->nullable()->after('is_defaulter');
+
+            $table->unique(['company_id', 'document_number'], 'clients_company_document_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clients', function (Blueprint $table): void {
+            $table->dropUnique('clients_company_document_unique');
+            $table->dropColumn(['credit_limit', 'is_defaulter', 'price_group']);
+        });
+    }
+};

--- a/database/migrations/2026_03_25_140000_add_sale_reference_type_to_stock_transactions_table.php
+++ b/database/migrations/2026_03_25_140000_add_sale_reference_type_to_stock_transactions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(
+            "ALTER TABLE stock_transactions
+             MODIFY COLUMN reference_type
+             ENUM('purchase_item','feeding','adjustment','transfer','stocking','sale') NOT NULL"
+        );
+    }
+
+    public function down(): void
+    {
+        DB::table('stock_transactions')
+            ->where('reference_type', 'sale')
+            ->update([
+                'reference_type' => 'stocking',
+            ]);
+
+        DB::statement(
+            "ALTER TABLE stock_transactions
+             MODIFY COLUMN reference_type
+             ENUM('purchase_item','feeding','adjustment','transfer','stocking') NOT NULL"
+        );
+    }
+};

--- a/routes/app/company/client.php
+++ b/routes/app/company/client.php
@@ -19,3 +19,6 @@ Route::middleware(['permission:update-client'])
 
 Route::middleware(['permission:delete-client'])
     ->delete('client/{id}', [ClientController::class, 'destroy']);
+
+Route::middleware(['permission:delete-client'])
+    ->delete('client/{id}/anonymize', [ClientController::class, 'anonymize']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,9 +2,17 @@
 
 declare(strict_types=1);
 
+use App\Console\Commands\MarkOverdueClientsCommand;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
 Artisan::command('inspire', function (): void {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+/*
+ * Daily agenda: mark/unmark overdue clients.
+ * To activate, uncomment the block below or add it to the Console Kernel.
+ */
+// app(Schedule::class)->command(MarkOverdueClientsCommand::class)->dailyAt('02:00');


### PR DESCRIPTION
- Implementa fluxo de cliente com DTOs/input, validação de documento (CPF/CNPJ) e guard de limite de crédito.
- Adiciona exceções de domínio para cliente (obrigações pendentes, dados fiscais, limite excedido e documento duplicado) com mapeamento no Handler.
- Trata erro de chave única no update de cliente (company_id + document_number) com resposta de domínio amigável.
- Padroniza payload camelCase em Client/Sale Requests (ex.: personType, pricePerKg) via prepareForValidation.
- Atualiza Resources e controller para consistência de saída.
- Adiciona migrations para unicidade de documento em clients e suporte a reference_type='sale' em stock_transactions.
- Inclui comando para marcar clientes inadimplentes e ajustes de rotas/console.
