### PR TITLE
docs(swagger): cobertura de documentação para controllers e ajustes de estilo

### DIFF
--- a/app/Presentation/Controllers/CompanyController.php
+++ b/app/Presentation/Controllers/CompanyController.php
@@ -18,12 +18,75 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Throwable;
 
+/**
+ * @OA\Schema(
+ *     schema="Company",
+ *     type="object",
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="name", type="string", example="Aquacultura Piuba"),
+ *     @OA\Property(property="cnpj", type="string", example="12.345.678/0001-90"),
+ *     @OA\Property(property="email", type="string", format="email", nullable=true),
+ *     @OA\Property(property="phone", type="string", example="(85) 99999-9999"),
+ *     @OA\Property(
+ *         property="address",
+ *         type="object",
+ *         @OA\Property(property="street", type="string", nullable=true),
+ *         @OA\Property(property="number", type="string", nullable=true),
+ *         @OA\Property(property="complement", type="string", nullable=true),
+ *         @OA\Property(property="neighborhood", type="string", nullable=true),
+ *         @OA\Property(property="city", type="string", nullable=true),
+ *         @OA\Property(property="state", type="string", nullable=true),
+ *         @OA\Property(property="zipCode", type="string", nullable=true)
+ *     ),
+ *     @OA\Property(property="active", type="boolean", example=true),
+ *     @OA\Property(property="status", type="string", enum={"active","inactive"}),
+ *     @OA\Property(property="createdAt", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="updatedAt", type="string", format="date-time", nullable=true)
+ * )
+ */
 class CompanyController
 {
     /**
      * Display a listing of companies.
      *
      * Query params: page (int), limit (int), search (string - filters by name, cnpj, email).
+     *
+     * @OA\Get(
+     *     path="/company/companies",
+     *     summary="List companies",
+     *     tags={"Companies"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="page", in="query", @OA\Schema(type="integer", example=1)),
+     *     @OA\Parameter(name="limit", in="query", @OA\Schema(type="integer", example=25)),
+     *     @OA\Parameter(name="search", in="query", @OA\Schema(type="string")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of companies",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(
+     *                 property="response",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="data",
+     *                     type="array",
+     *                     @OA\Items(ref="#/components/schemas/Company")
+     *                 )
+     *             ),
+     *             @OA\Property(
+     *                 property="pagination",
+     *                 type="object",
+     *                 @OA\Property(property="total", type="integer", example=1),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="first_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=25)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function index(Request $request, ShowAllCompaniesUseCase $useCase): JsonResponse
     {
@@ -43,6 +106,25 @@ class CompanyController
 
     /**
      * Display the specified company.
+     *
+     * @OA\Get(
+     *     path="/company/company/{id}",
+     *     summary="Get company by ID",
+     *     tags={"Companies"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Company found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Company")
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Company not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function show(string $id, ShowCompanyUseCase $useCase): JsonResponse
     {
@@ -61,6 +143,42 @@ class CompanyController
 
     /**
      * Store a newly created company.
+     *
+     * @OA\Post(
+     *     path="/company/company",
+     *     summary="Create company",
+     *     tags={"Companies"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name","cnpj","phone"},
+     *             @OA\Property(property="name", type="string", maxLength=255),
+     *             @OA\Property(property="cnpj", type="string", maxLength=18),
+     *             @OA\Property(property="email", type="string", format="email", nullable=true),
+     *             @OA\Property(property="phone", type="string", maxLength=20),
+     *             @OA\Property(property="addressStreet", type="string", nullable=true),
+     *             @OA\Property(property="addressNumber", type="string", nullable=true),
+     *             @OA\Property(property="addressComplement", type="string", nullable=true),
+     *             @OA\Property(property="addressNeighborhood", type="string", nullable=true),
+     *             @OA\Property(property="addressCity", type="string", nullable=true),
+     *             @OA\Property(property="addressState", type="string", nullable=true),
+     *             @OA\Property(property="addressZipCode", type="string", nullable=true),
+     *             @OA\Property(property="status", type="string", enum={"active","inactive"}, nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Company created",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Successfully created"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Company")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function store(CompanyStoreRequest $request, CreateCompanyUseCase $useCase): JsonResponse
     {
@@ -75,6 +193,43 @@ class CompanyController
 
     /**
      * Update the specified company.
+     *
+     * @OA\Put(
+     *     path="/company/company/{id}",
+     *     summary="Update company",
+     *     tags={"Companies"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="name", type="string", maxLength=255),
+     *             @OA\Property(property="cnpj", type="string", maxLength=18),
+     *             @OA\Property(property="email", type="string", format="email", nullable=true),
+     *             @OA\Property(property="phone", type="string", maxLength=20),
+     *             @OA\Property(property="addressStreet", type="string", nullable=true),
+     *             @OA\Property(property="addressNumber", type="string", nullable=true),
+     *             @OA\Property(property="addressComplement", type="string", nullable=true),
+     *             @OA\Property(property="addressNeighborhood", type="string", nullable=true),
+     *             @OA\Property(property="addressCity", type="string", nullable=true),
+     *             @OA\Property(property="addressState", type="string", nullable=true),
+     *             @OA\Property(property="addressZipCode", type="string", nullable=true),
+     *             @OA\Property(property="status", type="string", enum={"active","inactive"})
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Company updated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Company")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=404, description="Company not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function update(CompanyUpdateRequest $request, string $id, UpdateCompanyUseCase $useCase): JsonResponse
     {
@@ -89,6 +244,25 @@ class CompanyController
 
     /**
      * Remove the specified company.
+     *
+     * @OA\Delete(
+     *     path="/company/company/{id}",
+     *     summary="Delete company",
+     *     tags={"Companies"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Company deleted",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Company successfully deleted"),
+     *             @OA\Property(property="response", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Company not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function destroy(string $id, DeleteCompanyUseCase $useCase): JsonResponse
     {

--- a/app/Presentation/Controllers/CostAllocationController.php
+++ b/app/Presentation/Controllers/CostAllocationController.php
@@ -14,8 +14,92 @@ use App\Presentation\Response\ApiResponse;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
+/**
+ * @OA\Schema(
+ *     schema="CostAllocation",
+ *     type="object",
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="financialTransactionId", type="string", format="uuid"),
+ *     @OA\Property(property="allocationMethod", type="string", enum={"flat","biomass","volume"}),
+ *     @OA\Property(property="allocationMethodLabel", type="string", example="Biomass"),
+ *     @OA\Property(property="totalAmount", type="number", format="float", example=1200.5),
+ *     @OA\Property(property="notes", type="string", nullable=true),
+ *     @OA\Property(
+ *         property="company",
+ *         type="object",
+ *         nullable=true,
+ *         @OA\Property(property="id", type="string", format="uuid"),
+ *         @OA\Property(property="name", type="string")
+ *     ),
+ *     @OA\Property(
+ *         property="financialTransaction",
+ *         type="object",
+ *         nullable=true,
+ *         @OA\Property(property="id", type="string", format="uuid"),
+ *         @OA\Property(property="description", type="string", nullable=true),
+ *         @OA\Property(property="amount", type="number", format="float"),
+ *         @OA\Property(property="dueDate", type="string", format="date"),
+ *         @OA\Property(property="isAllocated", type="boolean")
+ *     ),
+ *     @OA\Property(
+ *         property="items",
+ *         type="array",
+ *         @OA\Items(
+ *             type="object",
+ *             @OA\Property(property="id", type="string", format="uuid"),
+ *             @OA\Property(property="stockingId", type="string", format="uuid"),
+ *             @OA\Property(property="percentage", type="number", format="float"),
+ *             @OA\Property(property="amount", type="number", format="float")
+ *         )
+ *     ),
+ *     @OA\Property(property="createdAt", type="string", format="date-time", nullable=true)
+ * )
+ */
 class CostAllocationController
 {
+    /**
+     * @OA\Get(
+     *     path="/company/cost-allocations",
+     *     summary="List cost allocations",
+     *     tags={"Cost Allocation"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="page", in="query", @OA\Schema(type="integer", example=1)),
+     *     @OA\Parameter(name="per_page", in="query", @OA\Schema(type="integer", example=25)),
+     *     @OA\Parameter(name="financial_transaction_id", in="query", @OA\Schema(type="string", format="uuid")),
+     *     @OA\Parameter(
+     *         name="allocation_method",
+     *         in="query",
+     *         @OA\Schema(type="string", enum={"flat","biomass","volume"})
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of cost allocations",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(
+     *                 property="response",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="data",
+     *                     type="array",
+     *                     @OA\Items(ref="#/components/schemas/CostAllocation")
+     *                 )
+     *             ),
+     *             @OA\Property(
+     *                 property="pagination",
+     *                 type="object",
+     *                 @OA\Property(property="total", type="integer", example=1),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="first_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=25)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function index(
         Request $request,
         ListCostAllocationsUseCase $useCase,
@@ -38,6 +122,26 @@ class CostAllocationController
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/company/cost-allocation/{id}",
+     *     summary="Get cost allocation by ID",
+     *     tags={"Cost Allocation"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Cost allocation found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/CostAllocation")
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Cost allocation not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function show(
         string $id,
         ShowCostAllocationUseCase $useCase,
@@ -47,6 +151,45 @@ class CostAllocationController
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/company/cost-allocation",
+     *     summary="Create cost allocation",
+     *     tags={"Cost Allocation"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"financial_transaction_id","allocation_method","allocations"},
+     *             @OA\Property(property="company_id", type="string", format="uuid", nullable=true),
+     *             @OA\Property(property="financial_transaction_id", type="string", format="uuid"),
+     *             @OA\Property(property="allocation_method", type="string", enum={"flat","biomass","volume"}),
+     *             @OA\Property(property="notes", type="string", nullable=true),
+     *             @OA\Property(
+     *                 property="allocations",
+     *                 type="array",
+     *                 @OA\Items(
+     *                     type="object",
+     *                     required={"stocking_id"},
+     *                     @OA\Property(property="stocking_id", type="string", format="uuid")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Cost allocation created",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Rateio de custo criado com sucesso."),
+     *             @OA\Property(property="response", ref="#/components/schemas/CostAllocation")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Business rule violation")
+     * )
+     */
     public function store(
         CostAllocationStoreRequest $request,
         CreateCostAllocationUseCase $useCase,
@@ -62,6 +205,29 @@ class CostAllocationController
     /**
      * Full reversal — deletes the allocation and undoes all side-effects.
      * Editing a partial allocation is intentionally NOT supported.
+     *
+     * @OA\Delete(
+     *     path="/company/cost-allocation/{id}",
+     *     summary="Reverse and delete cost allocation",
+     *     tags={"Cost Allocation"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Cost allocation reversed",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="message",
+     *                 type="string",
+     *                 example="Rateio estornado com sucesso. A transação financeira foi liberada para novo rateio."
+     *             ),
+     *             @OA\Property(property="response", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Cost allocation not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function destroy(
         string $id,

--- a/app/Presentation/Controllers/GrowthCurveController.php
+++ b/app/Presentation/Controllers/GrowthCurveController.php
@@ -17,10 +17,56 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Throwable;
 
+/**
+ * @OA\Schema(
+ *     schema="GrowthCurve",
+ *     type="object",
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="species", type="string", example="tilapia"),
+ *     @OA\Property(property="age", type="integer", example=30),
+ *     @OA\Property(property="expected_weight", type="number", format="float", example=120.5),
+ *     @OA\Property(property="created_at", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", nullable=true)
+ * )
+ */
 class GrowthCurveController
 {
     /**
-     * Display a listing of growth curves.
+     * @OA\Get(
+     *     path="/company/growth-curves",
+     *     summary="List growth curves",
+     *     tags={"Growth Curves"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="page", in="query", @OA\Schema(type="integer", example=1)),
+     *     @OA\Parameter(name="per_page", in="query", @OA\Schema(type="integer", example=25)),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of growth curves",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(
+     *                 property="response",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="data",
+     *                     type="array",
+     *                     @OA\Items(ref="#/components/schemas/GrowthCurve")
+     *                 )
+     *             ),
+     *             @OA\Property(
+     *                 property="pagination",
+     *                 type="object",
+     *                 @OA\Property(property="total", type="integer", example=1),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="first_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=25)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function index(ListGrowthCurvesUseCase $useCase): JsonResponse
     {
@@ -36,7 +82,24 @@ class GrowthCurveController
     }
 
     /**
-     * Display the specified growth curve.
+     * @OA\Get(
+     *     path="/company/growth-curve/{id}",
+     *     summary="Get growth curve by ID",
+     *     tags={"Growth Curves"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Growth curve found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/GrowthCurve")
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Growth curve not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function show(string $id, ShowGrowthCurveUseCase $useCase): JsonResponse
     {
@@ -54,7 +117,32 @@ class GrowthCurveController
     }
 
     /**
-     * Store a newly created growth curve.
+     * @OA\Post(
+     *     path="/company/growth-curve",
+     *     summary="Create growth curve",
+     *     tags={"Growth Curves"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"species","age","expected_weight"},
+     *             @OA\Property(property="species", type="string"),
+     *             @OA\Property(property="age", type="integer"),
+     *             @OA\Property(property="expected_weight", type="number", format="float")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Growth curve created",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Successfully created"),
+     *             @OA\Property(property="response", ref="#/components/schemas/GrowthCurve")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function store(GrowthCurveStoreRequest $request, CreateGrowthCurveUseCase $useCase): JsonResponse
     {
@@ -68,7 +156,33 @@ class GrowthCurveController
     }
 
     /**
-     * Update the specified growth curve.
+     * @OA\Put(
+     *     path="/company/growth-curve/{id}",
+     *     summary="Update growth curve",
+     *     tags={"Growth Curves"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="species", type="string"),
+     *             @OA\Property(property="age", type="integer"),
+     *             @OA\Property(property="expected_weight", type="number", format="float")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Growth curve updated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/GrowthCurve")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=404, description="Growth curve not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function update(
         GrowthCurveUpdateRequest $request,
@@ -85,7 +199,24 @@ class GrowthCurveController
     }
 
     /**
-     * Remove the specified growth curve.
+     * @OA\Delete(
+     *     path="/company/growth-curve/{id}",
+     *     summary="Delete growth curve",
+     *     tags={"Growth Curves"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Growth curve deleted",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Growth curve successfully deleted"),
+     *             @OA\Property(property="response", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Growth curve not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function destroy(string $id, DeleteGrowthCurveUseCase $useCase): JsonResponse
     {

--- a/app/Presentation/Controllers/HarvestController.php
+++ b/app/Presentation/Controllers/HarvestController.php
@@ -17,10 +17,58 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Throwable;
 
+/**
+ * @OA\Schema(
+ *     schema="Harvest",
+ *     type="object",
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="batchId", type="string", format="uuid"),
+ *     @OA\Property(property="harvestDate", type="string", format="date", example="2026-03-25"),
+ *     @OA\Property(property="totalWeight", type="number", format="float", example=850.5),
+ *     @OA\Property(property="pricePerKg", type="number", format="float", example=12.3),
+ *     @OA\Property(property="totalRevenue", type="number", format="float", example=10461.15),
+ *     @OA\Property(property="createdAt", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="updatedAt", type="string", format="date-time", nullable=true)
+ * )
+ */
 class HarvestController
 {
     /**
-     * Display a listing of harvests.
+     * @OA\Get(
+     *     path="/company/harvests",
+     *     summary="List harvests",
+     *     tags={"Harvest"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="page", in="query", @OA\Schema(type="integer", example=1)),
+     *     @OA\Parameter(name="per_page", in="query", @OA\Schema(type="integer", example=25)),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of harvests",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(
+     *                 property="response",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="data",
+     *                     type="array",
+     *                     @OA\Items(ref="#/components/schemas/Harvest")
+     *                 )
+     *             ),
+     *             @OA\Property(
+     *                 property="pagination",
+     *                 type="object",
+     *                 @OA\Property(property="total", type="integer", example=1),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="first_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=25)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function index(ListHarvestsUseCase $useCase): JsonResponse
     {
@@ -36,7 +84,24 @@ class HarvestController
     }
 
     /**
-     * Display the specified harvest.
+     * @OA\Get(
+     *     path="/company/harvest/{id}",
+     *     summary="Get harvest by ID",
+     *     tags={"Harvest"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Harvest found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Harvest")
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Harvest not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function show(string $id, ShowHarvestUseCase $useCase): JsonResponse
     {
@@ -54,7 +119,33 @@ class HarvestController
     }
 
     /**
-     * Store a newly created harvest.
+     * @OA\Post(
+     *     path="/company/harvest",
+     *     summary="Create harvest",
+     *     tags={"Harvest"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"batch_id","harvest_date","total_weight","price_per_kg"},
+     *             @OA\Property(property="batch_id", type="string", format="uuid"),
+     *             @OA\Property(property="harvest_date", type="string", format="date"),
+     *             @OA\Property(property="total_weight", type="number", format="float"),
+     *             @OA\Property(property="price_per_kg", type="number", format="float")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Harvest created",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Successfully created"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Harvest")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function store(HarvestStoreRequest $request, CreateHarvestUseCase $useCase): JsonResponse
     {
@@ -68,7 +159,33 @@ class HarvestController
     }
 
     /**
-     * Update the specified harvest.
+     * @OA\Put(
+     *     path="/company/harvest/{id}",
+     *     summary="Update harvest",
+     *     tags={"Harvest"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="harvest_date", type="string", format="date"),
+     *             @OA\Property(property="total_weight", type="number", format="float"),
+     *             @OA\Property(property="price_per_kg", type="number", format="float")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Harvest updated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Harvest")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=404, description="Harvest not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function update(HarvestUpdateRequest $request, string $id, UpdateHarvestUseCase $useCase): JsonResponse
     {
@@ -82,7 +199,24 @@ class HarvestController
     }
 
     /**
-     * Remove the specified harvest.
+     * @OA\Delete(
+     *     path="/company/harvest/{id}",
+     *     summary="Delete harvest",
+     *     tags={"Harvest"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Harvest deleted",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Harvest successfully deleted"),
+     *             @OA\Property(property="response", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Harvest not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function destroy(string $id, DeleteHarvestUseCase $useCase): JsonResponse
     {

--- a/app/Presentation/Controllers/SubscriptionController.php
+++ b/app/Presentation/Controllers/SubscriptionController.php
@@ -17,10 +17,63 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Throwable;
 
+/**
+ * @OA\Schema(
+ *     schema="Subscription",
+ *     type="object",
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="plan", type="string", enum={"basic","premium","enterprise"}),
+ *     @OA\Property(property="status", type="string", enum={"active","canceled"}),
+ *     @OA\Property(property="startDate", type="string", format="date"),
+ *     @OA\Property(property="endDate", type="string", format="date"),
+ *     @OA\Property(
+ *         property="company",
+ *         type="object",
+ *         nullable=true,
+ *         @OA\Property(property="name", type="string")
+ *     ),
+ *     @OA\Property(property="createdAt", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="updatedAt", type="string", format="date-time", nullable=true)
+ * )
+ */
 class SubscriptionController
 {
     /**
-     * Display a listing of subscriptions.
+     * @OA\Get(
+     *     path="/company/subscriptions",
+     *     summary="List subscriptions",
+     *     tags={"Subscriptions"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="page", in="query", @OA\Schema(type="integer", example=1)),
+     *     @OA\Parameter(name="per_page", in="query", @OA\Schema(type="integer", example=25)),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of subscriptions",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(
+     *                 property="response",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="data",
+     *                     type="array",
+     *                     @OA\Items(ref="#/components/schemas/Subscription")
+     *                 )
+     *             ),
+     *             @OA\Property(
+     *                 property="pagination",
+     *                 type="object",
+     *                 @OA\Property(property="total", type="integer", example=1),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="first_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=25)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function index(ListSubscriptionsUseCase $useCase): JsonResponse
     {
@@ -36,7 +89,24 @@ class SubscriptionController
     }
 
     /**
-     * Display the specified subscription.
+     * @OA\Get(
+     *     path="/company/subscription/{id}",
+     *     summary="Get subscription by ID",
+     *     tags={"Subscriptions"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Subscription found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Subscription")
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Subscription not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function show(string $id, ShowSubscriptionUseCase $useCase): JsonResponse
     {
@@ -54,7 +124,34 @@ class SubscriptionController
     }
 
     /**
-     * Store a newly created subscription.
+     * @OA\Post(
+     *     path="/company/subscription",
+     *     summary="Create subscription",
+     *     tags={"Subscriptions"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"company_id","plan","start_date","end_date","status"},
+     *             @OA\Property(property="company_id", type="string", format="uuid"),
+     *             @OA\Property(property="plan", type="string", enum={"basic","premium","enterprise"}),
+     *             @OA\Property(property="start_date", type="string", format="date"),
+     *             @OA\Property(property="end_date", type="string", format="date"),
+     *             @OA\Property(property="status", type="string", enum={"active","canceled"})
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Subscription created",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Successfully created"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Subscription")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function store(SubscriptionStoreRequest $request, CreateSubscriptionUseCase $useCase): JsonResponse
     {
@@ -68,7 +165,35 @@ class SubscriptionController
     }
 
     /**
-     * Update the specified subscription.
+     * @OA\Put(
+     *     path="/company/subscription/{id}",
+     *     summary="Update subscription",
+     *     tags={"Subscriptions"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="company_id", type="string", format="uuid"),
+     *             @OA\Property(property="plan", type="string", enum={"basic","premium","enterprise"}),
+     *             @OA\Property(property="start_date", type="string", format="date"),
+     *             @OA\Property(property="end_date", type="string", format="date"),
+     *             @OA\Property(property="status", type="string", enum={"active","canceled"})
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Subscription updated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Subscription")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=404, description="Subscription not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function update(
         SubscriptionUpdateRequest $request,
@@ -85,7 +210,24 @@ class SubscriptionController
     }
 
     /**
-     * Remove the specified subscription.
+     * @OA\Delete(
+     *     path="/company/subscription/{id}",
+     *     summary="Delete subscription",
+     *     tags={"Subscriptions"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Subscription deleted",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Subscription successfully deleted"),
+     *             @OA\Property(property="response", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Subscription not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function destroy(string $id, DeleteSubscriptionUseCase $useCase): JsonResponse
     {

--- a/app/Presentation/Controllers/SupplierController.php
+++ b/app/Presentation/Controllers/SupplierController.php
@@ -17,10 +17,63 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Throwable;
 
+/**
+ * @OA\Schema(
+ *     schema="Supplier",
+ *     type="object",
+ *     @OA\Property(property="id", type="string", format="uuid"),
+ *     @OA\Property(property="name", type="string", example="Fornecedor Nordeste"),
+ *     @OA\Property(property="contact", type="string", example="Joao Silva"),
+ *     @OA\Property(property="phone", type="string", example="(85) 99999-0000"),
+ *     @OA\Property(property="email", type="string", format="email", example="contato@fornecedor.com"),
+ *     @OA\Property(
+ *         property="company",
+ *         type="object",
+ *         nullable=true,
+ *         @OA\Property(property="name", type="string")
+ *     ),
+ *     @OA\Property(property="createdAt", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="updatedAt", type="string", format="date-time", nullable=true)
+ * )
+ */
 class SupplierController
 {
     /**
-     * Display a listing of suppliers.
+     * @OA\Get(
+     *     path="/company/suppliers",
+     *     summary="List suppliers",
+     *     tags={"Suppliers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="page", in="query", @OA\Schema(type="integer", example=1)),
+     *     @OA\Parameter(name="per_page", in="query", @OA\Schema(type="integer", example=25)),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of suppliers",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(
+     *                 property="response",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="data",
+     *                     type="array",
+     *                     @OA\Items(ref="#/components/schemas/Supplier")
+     *                 )
+     *             ),
+     *             @OA\Property(
+     *                 property="pagination",
+     *                 type="object",
+     *                 @OA\Property(property="total", type="integer", example=1),
+     *                 @OA\Property(property="current_page", type="integer", example=1),
+     *                 @OA\Property(property="last_page", type="integer", example=1),
+     *                 @OA\Property(property="first_page", type="integer", example=1),
+     *                 @OA\Property(property="per_page", type="integer", example=25)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function index(ListSuppliersUseCase $useCase): JsonResponse
     {
@@ -36,7 +89,24 @@ class SupplierController
     }
 
     /**
-     * Display the specified supplier.
+     * @OA\Get(
+     *     path="/company/supplier/{id}",
+     *     summary="Get supplier by ID",
+     *     tags={"Suppliers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Supplier found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Supplier")
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Supplier not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function show(string $id, ShowSupplierUseCase $useCase): JsonResponse
     {
@@ -54,7 +124,34 @@ class SupplierController
     }
 
     /**
-     * Store a newly created supplier.
+     * @OA\Post(
+     *     path="/company/supplier",
+     *     summary="Create supplier",
+     *     tags={"Suppliers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"company_id","name","contact","phone","email"},
+     *             @OA\Property(property="company_id", type="string", format="uuid"),
+     *             @OA\Property(property="name", type="string", maxLength=255),
+     *             @OA\Property(property="contact", type="string", maxLength=255),
+     *             @OA\Property(property="phone", type="string", maxLength=20),
+     *             @OA\Property(property="email", type="string", format="email", maxLength=255)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Supplier created",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Successfully created"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Supplier")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function store(SupplierStoreRequest $request, CreateSupplierUseCase $useCase): JsonResponse
     {
@@ -68,7 +165,35 @@ class SupplierController
     }
 
     /**
-     * Update the specified supplier.
+     * @OA\Put(
+     *     path="/company/supplier/{id}",
+     *     summary="Update supplier",
+     *     tags={"Suppliers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="company_id", type="string", format="uuid"),
+     *             @OA\Property(property="name", type="string", maxLength=255),
+     *             @OA\Property(property="contact", type="string", maxLength=255),
+     *             @OA\Property(property="phone", type="string", maxLength=20),
+     *             @OA\Property(property="email", type="string", format="email", maxLength=255)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Supplier updated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Success"),
+     *             @OA\Property(property="response", ref="#/components/schemas/Supplier")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Validation error"),
+     *     @OA\Response(response=404, description="Supplier not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function update(SupplierUpdateRequest $request, string $id, UpdateSupplierUseCase $useCase): JsonResponse
     {
@@ -82,7 +207,24 @@ class SupplierController
     }
 
     /**
-     * Remove the specified supplier.
+     * @OA\Delete(
+     *     path="/company/supplier/{id}",
+     *     summary="Delete supplier",
+     *     tags={"Suppliers"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Supplier deleted",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Supplier successfully deleted"),
+     *             @OA\Property(property="response", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Supplier not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function destroy(string $id, DeleteSupplierUseCase $useCase): JsonResponse
     {


### PR DESCRIPTION

- Implementa documentação OpenAPI em CostAllocationController, GrowthCurveController, HarvestController, SubscriptionController, SupplierController e CompanyController.
- Documenta schemas, parâmetros de query/path, request bodies e respostas de sucesso/erro.
- Ajusta anotações longas e formatação para manter PHPCS/PSR-12 sem warnings.
- Mantém compatibilidade com o padrão de resposta da API (ApiResponse) e organização por tags.