### PR TITLE
feat(sales-order): adiciona módulo completo de pedidos e cotações de venda

### DIFF
--- a/app/Application/Actions/Batch/CalculateProportionalCostAction.php
+++ b/app/Application/Actions/Batch/CalculateProportionalCostAction.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Batch;
+
+final readonly class CalculateProportionalCostAction
+{
+    public function execute(int $quantity, int $totalQuantity, float $totalCost): float
+    {
+        if ($totalQuantity === 0) {
+            return 0.0;
+        }
+
+        return ($quantity / $totalQuantity) * $totalCost;
+    }
+}

--- a/app/Application/Actions/Batch/CreateDistributedBatchesAction.php
+++ b/app/Application/Actions/Batch/CreateDistributedBatchesAction.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Batch;
+
+use App\Application\Actions\FinancialTransaction\GeneratePayableAction;
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Application\DTOs\BatchDistributionInputDTO;
+use App\Application\DTOs\ExpenseInputDTO;
+use App\Domain\Enums\FinancialTransactionStatus;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+final readonly class CreateDistributedBatchesAction
+{
+    public function __construct(
+        private CompanyResolverInterface $companyResolver,
+        private CreateSingleDistributedBatchAction $createSingleBatch,
+        private GeneratePayableAction $generatePayable,
+    ) {
+    }
+
+    /**
+     * @return Collection<int, \App\Domain\Models\Batch>
+     */
+    public function execute(BatchDistributionInputDTO $input): Collection
+    {
+        $parentGroupId   = Str::uuid()->toString();
+        $totalQuantity   = $input->getTotalQuantity();
+        $companyId       = $this->companyResolver->resolve();
+        $expenseInputDTO = new ExpenseInputDTO(
+            companyId: $companyId,
+            amount: $input->totalCost,
+            expenseDate: $input->entryDate,
+            financialCategoryId: null,
+            supplierId: $input->supplierId,
+            costCenterId: null,
+            description: null,
+            notes: $input->notes,
+            status: FinancialTransactionStatus::PENDING,
+        );
+
+        $this->generatePayable->execute($expenseInputDTO, $parentGroupId);
+
+        return $this->createBatchesForDistribution(
+            $input,
+            $parentGroupId,
+            $totalQuantity,
+        );
+    }
+
+    /**
+     * @return Collection<int, \App\Domain\Models\Batch>
+     */
+    private function createBatchesForDistribution(
+        BatchDistributionInputDTO $input,
+        string $parentGroupId,
+        int $totalQuantity,
+    ): Collection {
+        $createdBatches = collect();
+
+        foreach ($input->distribution as $item) {
+            $batch = $this->createSingleBatch->execute(
+                $input,
+                $item,
+                $parentGroupId,
+                $totalQuantity
+            );
+
+            $createdBatches->push($batch);
+        }
+
+        return $createdBatches;
+    }
+}

--- a/app/Application/Actions/Batch/CreateSingleDistributedBatchAction.php
+++ b/app/Application/Actions/Batch/CreateSingleDistributedBatchAction.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Batch;
+
+use App\Application\DTOs\BatchDistributionInputDTO;
+use App\Application\DTOs\BatchInputDTO;
+use App\Domain\Repositories\BatchRepositoryInterface;
+
+final readonly class CreateSingleDistributedBatchAction
+{
+    public function __construct(
+        private BatchRepositoryInterface $repository,
+        private CalculateProportionalCostAction $calculateCost,
+        private GenerateBatchNameAction $generateName,
+    ) {
+    }
+
+    /**
+     * @param array{tankId: string, quantity: int, averageWeight?: float} $item
+     */
+    public function execute(
+        BatchDistributionInputDTO $input,
+        array $item,
+        string $parentGroupId,
+        int $totalQuantity
+    ): \App\Domain\Models\Batch {
+        $proportionalCost = $this->calculateCost->execute(
+            $item['quantity'],
+            $totalQuantity,
+            $input->totalCost
+        );
+
+        $unitCost = $item['quantity'] > 0
+            ? $proportionalCost / $item['quantity']
+            : 0.0;
+
+        $batchDto = new BatchInputDTO(
+            name: $this->generateName->execute($input->species, $item['quantity']),
+            description: $input->notes,
+            species: $input->species,
+            initialQuantity: $item['quantity'],
+            entryDate: $input->entryDate,
+            tankId: $item['tankId'],
+            status: 'active',
+            cultivation: $input->cultivation,
+            parentGroupId: $parentGroupId,
+            unitCost: $unitCost,
+            totalCost: $proportionalCost,
+        );
+
+        return $this->repository->create($batchDto);
+    }
+}

--- a/app/Application/Actions/Batch/GenerateBatchNameAction.php
+++ b/app/Application/Actions/Batch/GenerateBatchNameAction.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Batch;
+
+final readonly class GenerateBatchNameAction
+{
+    public function execute(string $species, int $quantity): string
+    {
+        return sprintf('Lot - %s (%d un)', $species, $quantity);
+    }
+}

--- a/app/Application/Actions/Batch/ValidateTanksForDistributionAction.php
+++ b/app/Application/Actions/Batch/ValidateTanksForDistributionAction.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Batch;
+
+use App\Application\DTOs\BatchDistributionInputDTO;
+
+final readonly class ValidateTanksForDistributionAction
+{
+    public function __construct(
+        private ValidateActiveBatchInTankAction $validateTank,
+    ) {
+    }
+
+    /**
+     * @throws \App\Domain\Exceptions\TankAlreadyHasActiveBatchException
+     */
+    public function execute(BatchDistributionInputDTO $input): void
+    {
+        foreach ($input->distribution as $item) {
+            $this->validateTank->execute($item['tankId']);
+        }
+    }
+}

--- a/app/Application/Actions/Client/GuardClientCreditAction.php
+++ b/app/Application/Actions/Client/GuardClientCreditAction.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace App\Application\Actions\Client;
 
-use App\Domain\Enums\FinancialTransactionStatus;
+use App\Application\Services\Client\ClientCreditService;
 use App\Domain\Exceptions\ClientCreditLimitExceededException;
-use App\Domain\Models\Client;
-use Illuminate\Support\Facades\DB;
+use App\Domain\Repositories\ClientRepositoryInterface;
 
 /**
  * Verifica se o cliente possui limite de crédito definido e se a nova venda
@@ -17,39 +16,19 @@ use Illuminate\Support\Facades\DB;
  */
 final readonly class GuardClientCreditAction
 {
+    public function __construct(
+        private ClientRepositoryInterface $clientRepository,
+        private ClientCreditService $creditService,
+    ) {
+    }
+
     /**
      * @throws ClientCreditLimitExceededException
      */
     public function execute(string $clientId, float $newSaleAmount): void
     {
-        /** @var Client|null $client */
-        $client = Client::find($clientId);
+        $client = $this->clientRepository->findOrFail($clientId);
 
-        if ($client === null || $client->credit_limit === null) {
-            return;
-        }
-
-        $creditLimit = (float) $client->credit_limit;
-
-        $currentExposure = (float) DB::table('financial_transactions')
-            ->join('sales', 'sales.id', '=', 'financial_transactions.reference_id')
-            ->where('sales.client_id', $clientId)
-            ->where('financial_transactions.reference_type', 'sale')
-            ->whereIn('financial_transactions.status', [
-                FinancialTransactionStatus::PENDING->value,
-                FinancialTransactionStatus::OVERDUE->value,
-            ])
-            ->whereNull('financial_transactions.deleted_at')
-            ->whereNull('sales.deleted_at')
-            ->sum('financial_transactions.amount');
-
-        if (($currentExposure + $newSaleAmount) > $creditLimit) {
-            throw new ClientCreditLimitExceededException(
-                clientId:        $clientId,
-                creditLimit:     $creditLimit,
-                currentExposure: $currentExposure,
-                newSaleAmount:   $newSaleAmount,
-            );
-        }
+        $this->creditService->guardCreditLimit($client, $newSaleAmount);
     }
 }

--- a/app/Application/Actions/FinancialTransaction/GeneratePayableAction.php
+++ b/app/Application/Actions/FinancialTransaction/GeneratePayableAction.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\FinancialTransaction;
+
+use App\Application\DTOs\ExpenseInputDTO;
+use App\Application\DTOs\FinancialTransactionInputDTO;
+use App\Application\Services\FinancialTransactionService;
+use App\Domain\Enums\FinancialTransactionReferenceType;
+use App\Domain\Enums\FinancialTransactionStatus;
+use App\Domain\Enums\FinancialType;
+use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
+
+/**
+ * Gera automaticamente o "Contas a Pagar" (PENDING) vinculado à despesa.
+ *
+ * Não executa se financialCategoryId for null.
+ * Chamada dentro de DB::transaction — atomicidade garantida pelo chamador.
+ */
+final readonly class GeneratePayableAction
+{
+    public function __construct(
+        private FinancialTransactionRepositoryInterface $transactionRepository,
+        private FinancialTransactionService $transactionService,
+    ) {
+    }
+
+    public function execute(ExpenseInputDTO $dto, string $referenceId): void
+    {
+        if ($dto->financialCategoryId === null) {
+            return;
+        }
+
+        $this->transactionService->validateCategoryType(
+            categoryId:      $dto->financialCategoryId,
+            transactionType: FinancialType::EXPENSE,
+        );
+
+        $payableDTO = new FinancialTransactionInputDTO(
+            companyId:           $dto->companyId,
+            financialCategoryId: $dto->financialCategoryId,
+            type:                FinancialType::EXPENSE,
+            amount:              $dto->totalExpense(),
+            dueDate:             $dto->expenseDate,
+            status:              FinancialTransactionStatus::PENDING,
+            paymentDate:         null,
+            description:         "Contas a Pagar — Item de Compra #{$referenceId}",
+            notes:               $dto->notes,
+            referenceType:       FinancialTransactionReferenceType::PURCHASE_ITEM,
+            referenceId:         $referenceId,
+        );
+
+        $this->transactionRepository->create(
+            $this->transactionService->applyPaymentDateToDTO($payableDTO),
+        );
+    }
+}

--- a/app/Application/Actions/Sale/CancelSaleReceivablesAction.php
+++ b/app/Application/Actions/Sale/CancelSaleReceivablesAction.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Sale;
+
+use App\Domain\Enums\FinancialTransactionStatus;
+use App\Domain\Exceptions\SaleFinanciallyLockedException;
+use App\Domain\Models\FinancialTransaction;
+use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
+use Illuminate\Support\Collection;
+
+final readonly class CancelSaleReceivablesAction
+{
+    public function __construct(
+        private FinancialTransactionRepositoryInterface $transactionRepository,
+    ) {
+    }
+
+    /**
+     * Cancela todas as transações financeiras vinculadas à venda.
+     *
+     * Trava financeira: se qualquer transação estiver paga (paid),
+     * a venda não pode ser deletada — lança SaleFinanciallyLockedException.
+     *
+     * Transações overdue ou pending são canceladas normalmente.
+     * Transações já canceladas são ignoradas (idempotência).
+     *
+     * @throws SaleFinanciallyLockedException
+     */
+    public function execute(string $saleId): void
+    {
+        /** @var Collection<int, FinancialTransaction> $transactions */
+        $transactions = $this->transactionRepository->findLockedBySaleId($saleId);
+
+        if ($transactions->isEmpty()) {
+            return;
+        }
+
+        foreach ($transactions as $tx) {
+            // Paga = dinheiro já entrou no caixa → não pode desfazer
+            if ($tx->status === FinancialTransactionStatus::PAID) {
+                throw new SaleFinanciallyLockedException();
+            }
+        }
+
+        foreach ($transactions as $tx) {
+            if ($tx->status === FinancialTransactionStatus::CANCELLED) {
+                continue; // Já cancelada — nada a fazer
+            }
+
+            $this->transactionRepository->update((string) $tx->id, [
+                'status' => FinancialTransactionStatus::CANCELLED->value,
+            ]);
+        }
+    }
+}

--- a/app/Application/Actions/Sale/CloseStockingAndBatchAction.php
+++ b/app/Application/Actions/Sale/CloseStockingAndBatchAction.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Sale;
+
+use App\Domain\Enums\BatchStatus;
+use App\Domain\Models\Stocking;
+use App\Domain\Repositories\BatchRepositoryInterface;
+use App\Domain\Repositories\StockingRepositoryInterface;
+
+final readonly class CloseStockingAndBatchAction
+{
+    public function __construct(
+        private StockingRepositoryInterface $stockingRepository,
+        private BatchRepositoryInterface $batchRepository,
+    ) {
+    }
+
+    /**
+     * Regra 4 da despesca total:
+     *  1. Encerra o status do povoamento (stocking).
+     *  2. SE não houver outros povoamentos ativos no mesmo lote → encerra o lote também.
+     *
+     * Chamada dentro da DB::transaction do UseCase — atomicidade garantida.
+     */
+    public function execute(Stocking $stocking): void
+    {
+        // Passo 1: Encerra o povoamento
+        $stocking->markAsClosed();
+
+        // Passo 2: Verifica se existem outros povoamentos ativos no lote
+        $hasOtherActiveStockings = $this->stockingRepository
+            ->hasActiveStockingsInBatch(
+                batchId:          (string) $stocking->batch_id,
+                excludeStockingId: (string) $stocking->id,
+            );
+
+        if (! $hasOtherActiveStockings) {
+            // Não há mais nenhum povoamento ativo — encerra o lote também
+            $this->batchRepository->update((string) $stocking->batch_id, [
+                'status' => BatchStatus::FINISHED->value,
+            ]);
+        }
+    }
+}

--- a/app/Application/Actions/Sale/GenerateReceivableAction.php
+++ b/app/Application/Actions/Sale/GenerateReceivableAction.php
@@ -13,6 +13,12 @@ use App\Domain\Enums\FinancialType;
 use App\Domain\Models\Sale;
 use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
 
+/**
+ * Gera automaticamente o "Contas a Receber" (PENDING) vinculado à venda.
+ *
+ * Não executa se financialCategoryId for null.
+ * Chamada dentro de DB::transaction — atomicidade garantida pelo chamador.
+ */
 final readonly class GenerateReceivableAction
 {
     public function __construct(
@@ -21,20 +27,12 @@ final readonly class GenerateReceivableAction
     ) {
     }
 
-    /**
-     * Gera automaticamente o "Contas a Receber" (PENDING) vinculado à venda.
-     * Não executa se financialCategoryId for null — venda sem vinculação financeira.
-     *
-     * Valida que a categoria é do tipo REVENUE antes de persistir,
-     * usando FinancialTransactionService como fonte única dessa regra.
-     */
     public function execute(SaleInputDTO $dto, Sale $sale): void
     {
         if ($dto->financialCategoryId === null) {
             return;
         }
 
-        // Valida que a categoria é REVENUE — regra de negócio do domínio financeiro
         $this->transactionService->validateCategoryType(
             categoryId:      $dto->financialCategoryId,
             transactionType: FinancialType::REVENUE,
@@ -47,15 +45,14 @@ final readonly class GenerateReceivableAction
             amount:              $dto->totalRevenue(),
             dueDate:             $dto->saleDate,
             status:              FinancialTransactionStatus::PENDING,
-            paymentDate:         null, // status PENDING → sem data de pagamento
+            paymentDate:         null,
             description:         "Contas a Receber — Venda #{$sale->id}",
             referenceType:       FinancialTransactionReferenceType::SALE,
             referenceId:         (string) $sale->id,
         );
 
-        // Aplica regras de payment_date (no-op aqui pois status = PENDING)
-        $resolvedDTO = $this->transactionService->applyPaymentDateToDTO($receivableDTO);
-
-        $this->transactionRepository->create($resolvedDTO);
+        $this->transactionRepository->create(
+            $this->transactionService->applyPaymentDateToDTO($receivableDTO),
+        );
     }
 }

--- a/app/Application/Actions/Sale/GuardBiomassAction.php
+++ b/app/Application/Actions/Sale/GuardBiomassAction.php
@@ -11,6 +11,12 @@ use Illuminate\Support\Facades\Log;
 
 final readonly class GuardBiomassAction
 {
+    /**
+     * Tolerância de segurança padrão: 50% acima da biomassa estimada.
+     * Cobre variações naturais de peso (ciclo lunar, jejum pré-despesca, etc.).
+     */
+    private const float DEFAULT_TOLERANCE_PERCENT = 50.0;
+
     public function __construct(
         private SaleRepositoryInterface $saleRepository,
     ) {
@@ -18,7 +24,7 @@ final readonly class GuardBiomassAction
 
     /**
      * Valida biomassa disponível sem margem de tolerância.
-     * Usada em fluxos simples de venda sem despesca total.
+     * Usada no Update (revalidação simples sem flag de despesca).
      *
      * @throws InsufficientBiomassException
      */
@@ -27,48 +33,57 @@ final readonly class GuardBiomassAction
         float $requestedWeight,
         ?string $excludeSaleId = null,
     ): void {
-        $available = $stocking->initialBiomass()
-            - $this->saleRepository->soldWeightByStocking($stocking->id, $excludeSaleId);
+        [$available] = $this->resolveAvailability($stocking, $excludeSaleId);
 
         if ($requestedWeight > $available) {
             throw new InsufficientBiomassException(
                 available:  $available,
                 requested:  $requestedWeight,
-                stockingId: $stocking->id,
+                stockingId: (string) $stocking->id,
             );
         }
     }
 
     /**
-     * Valida biomassa com margem de tolerância configurável.
-     * Usada em despescas onde há variação natural de peso.
+     * Valida biomassa com tolerância de 50% (regra 2 da despesca).
      *
-     * Acima da estimativa mas dentro da tolerância → warning (não bloqueia).
-     * Acima da tolerância → InsufficientBiomassException.
+     * Fórmula da biomassa disponível:
+     *   (current_quantity × avg_weight) − soma_de_peso_já_vendido_deste_stocking
+     *
+     * Limite com tolerância:
+     *   disponível × (1 + tolerancePercent / 100)
+     *
+     * Fluxo:
+     *  - requestedWeight ≤ disponível          → OK silencioso
+     *  - disponível < requestedWeight ≤ limite  → warning (log) + OK
+     *  - requestedWeight > limite               → InsufficientBiomassException + rollback
      *
      * @throws InsufficientBiomassException
      */
     public function executeWithTolerance(
         Stocking $stocking,
         float $requestedWeight,
-        float $tolerancePercent,
+        float $tolerancePercent = self::DEFAULT_TOLERANCE_PERCENT,
         ?string $excludeSaleId = null,
     ): void {
-        $committedWeight = $this->saleRepository->soldWeightByStocking($stocking->id, $excludeSaleId);
-        $available       = $stocking->initialBiomass() - $committedWeight;
-        $toleranceLimit  = $available * (1 + $tolerancePercent / 100);
+        [$available, $committedWeight] = $this->resolveAvailability($stocking, $excludeSaleId);
+
+        $toleranceLimit = $available * (1 + $tolerancePercent / 100);
 
         if ($requestedWeight > $toleranceLimit) {
             throw new InsufficientBiomassException(
                 available:  $toleranceLimit,
                 requested:  $requestedWeight,
-                stockingId: $stocking->id,
+                stockingId: (string) $stocking->id,
             );
         }
 
         if ($requestedWeight > $available) {
-            Log::warning('Harvest adjustment: requested weight exceeds biomass estimate but is within tolerance.', [
+            Log::warning('Harvest adjustment: weight exceeds biomass estimate but within tolerance.', [
                 'stocking_id'       => $stocking->id,
+                'current_quantity'  => $stocking->current_quantity,
+                'avg_weight_kg'     => $stocking->average_weight,
+                'committed_kg'      => $committedWeight,
                 'available_kg'      => $available,
                 'requested_kg'      => $requestedWeight,
                 'tolerance_percent' => $tolerancePercent,
@@ -76,5 +91,32 @@ final readonly class GuardBiomassAction
                 'excess_kg'         => round($requestedWeight - $available, 4),
             ]);
         }
+    }
+
+    /**
+     * Calcula a biomassa disponível do povoamento.
+     *
+     * Regra 2 (fórmula exata):
+     *   disponível = (current_quantity × average_weight) − peso_já_vendido_do_stocking
+     *
+     * Retorna [disponível, pesoComprometido] para evitar recalcular.
+     *
+     * @return array{float, float}
+     */
+    private function resolveAvailability(Stocking $stocking, ?string $excludeSaleId): array
+    {
+        // Biomassa atual estimada do povoamento
+        $currentBiomass = (float) $stocking->current_quantity
+                        * (float) $stocking->average_weight;
+
+        // Peso já comprometido em vendas anteriores deste MESMO stocking_id
+        $committedWeight = $this->saleRepository->soldWeightByStocking(
+            (string) $stocking->id,
+            $excludeSaleId,
+        );
+
+        $available = $currentBiomass - $committedWeight;
+
+        return [$available, $committedWeight];
     }
 }

--- a/app/Application/Actions/Sale/GuardClientFiscalDataAction.php
+++ b/app/Application/Actions/Sale/GuardClientFiscalDataAction.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Sale;
+
+use App\Domain\Exceptions\ClientMissingFiscalDataException;
+use App\Domain\Repositories\ClientRepositoryInterface;
+
+final readonly class GuardClientFiscalDataAction
+{
+    public function __construct(
+        private ClientRepositoryInterface $clientRepository,
+    ) {
+    }
+
+    /**
+     * Valida que o cliente possui os dados fiscais obrigatórios para emissão de nota fiscal:
+     *  - document_number (CPF ou CNPJ)
+     *  - address
+     *
+     * Só executa se $needsInvoice for true.
+     *
+     * @throws ClientMissingFiscalDataException
+     */
+    public function execute(string $clientId, bool $needsInvoice): void
+    {
+        if (! $needsInvoice) {
+            return;
+        }
+
+        $client = $this->clientRepository->findOrFail($clientId);
+
+        if (empty($client->document_number) || empty($client->address)) {
+            throw new ClientMissingFiscalDataException($clientId);
+        }
+    }
+}

--- a/app/Application/Actions/Sale/HarvestLifecycleAction.php
+++ b/app/Application/Actions/Sale/HarvestLifecycleAction.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Sale;
+
+use App\Domain\Enums\BatchStatus;
+use App\Domain\Models\Batch;
+use App\Domain\Models\Stocking;
+use App\Domain\Repositories\BatchRepositoryInterface;
+use App\Domain\Repositories\StockingRepositoryInterface;
+use App\Domain\Repositories\TankRepositoryInterface;
+
+/**
+ * Action que gerencia transições de ciclo de vida do stocking/batch
+ * quando o campo `is_total_harvest` de uma venda é alterado.
+ *
+ * Substitui a dupla CloseStockingAndBatchAction + ReopenStockingAndBatchAction,
+ * que eram dois lados da mesma responsabilidade e dependiam uma da outra
+ * contextualmente (o UseCase decidia qual chamar).
+ *
+ * Regras de negócio encapsuladas:
+ *   - Ativar despesca total  → fecha stocking; fecha batch se não houver outros ativos
+ *   - Reverter despesca total → reabre stocking; reabre batch + tank se batch estava fechado
+ *
+ * Chamada dentro de DB::transaction — atomicidade garantida pelo chamador.
+ */
+final readonly class HarvestLifecycleAction
+{
+    public function __construct(
+        private StockingRepositoryInterface $stockingRepository,
+        private BatchRepositoryInterface $batchRepository,
+        private TankRepositoryInterface $tankRepository,
+    ) {
+    }
+
+    /**
+     * Aplica a transição de ciclo de vida adequada com base na mudança de `is_total_harvest`.
+     *
+     * Idempotente: se old === new, nenhuma escrita é realizada.
+     */
+    public function apply(
+        Stocking $stocking,
+        bool $oldIsTotalHarvest,
+        bool $newIsTotalHarvest,
+        string $batchId,
+    ): void {
+        if ($oldIsTotalHarvest === $newIsTotalHarvest) {
+            return;
+        }
+
+        if ($oldIsTotalHarvest && ! $newIsTotalHarvest) {
+            $this->reopen($stocking, $batchId);
+
+            return;
+        }
+
+        if (! $oldIsTotalHarvest && $newIsTotalHarvest && ! $stocking->isClosed()) {
+            $this->close($stocking);
+        }
+    }
+
+    /**
+     * Encerra stocking e, se necessário, encerra o batch.
+     *
+     * Regra: só encerra o batch quando não existirem outros stockings ativos no mesmo lote.
+     */
+    private function close(Stocking $stocking): void
+    {
+        $stocking->markAsClosed();
+
+        $hasOtherActiveStockings = $this->stockingRepository->hasActiveStockingsInBatch(
+            batchId:           (string) $stocking->batch_id,
+            excludeStockingId: (string) $stocking->id,
+        );
+
+        if (! $hasOtherActiveStockings) {
+            $this->batchRepository->update((string) $stocking->batch_id, [
+                'status' => BatchStatus::FINISHED->value,
+            ]);
+        }
+    }
+
+    /**
+     * Reabre stocking e, se o batch estava encerrado, reabre batch + tank.
+     *
+     * Nota: o tank é reaberto aqui (não no CloseStockingAndBatchAction original)
+     * porque o encerramento do tank é consequência do encerramento do batch —
+     * a reversão deve ser simétrica.
+     */
+    private function reopen(Stocking $stocking, string $batchId): void
+    {
+        $this->stockingRepository->update((string) $stocking->id, [
+            'status'    => 'active',
+            'closed_at' => null,
+        ]);
+
+        /** @var Batch $batch */
+        $batch = $this->batchRepository->findOrFail($batchId);
+
+        if (! $batch->isFinished()) {
+            return;
+        }
+
+        $this->batchRepository->update($batchId, [
+            'status' => BatchStatus::ACTIVE->value,
+        ]);
+
+        $this->tankRepository->update((string) $batch->tank_id, [
+            'status' => 'active',
+        ]);
+    }
+}

--- a/app/Application/Actions/Sale/RegisterBiomassOutflowAction.php
+++ b/app/Application/Actions/Sale/RegisterBiomassOutflowAction.php
@@ -12,30 +12,31 @@ use App\Domain\Enums\Unit;
 use App\Domain\Models\Sale;
 use App\Domain\Models\Stocking;
 use App\Domain\Models\StockTransaction;
+use App\Domain\Repositories\StockingRepositoryInterface;
 
 final readonly class RegisterBiomassOutflowAction
 {
     public function __construct(
         private RegisterStockTransactionAction $registerStockTransaction,
+        private StockingRepositoryInterface $stockingRepository,
     ) {
     }
 
     /**
-     * Registra a saída de biomassa no livro-razão (stock_transactions).
+     * Regra 3 - CMV exato por stocking_id.
+     * O unit_price e calculado pelo custo financeiro acumulado do POVOAMENTO.
      *
-     * O unit_price é o custo unitário acumulado do lote, calculado com base
-     * no peso já vendido anteriormente — isso garante o custo correto por kg
-     * para cálculo de lucro por tanque.
+     * Formula: custo_total_acumulado_do_stocking / biomassa_restante
      *
-     * @param float $alreadySoldWeight Peso vendido ANTES desta venda (exclui a atual)
+     * @param float $alreadySoldWeight Peso ja vendido ANTES desta venda
      */
     public function execute(
         Stocking $stocking,
         Sale $sale,
         float $alreadySoldWeight,
     ): StockTransaction {
-        $unitCost  = $stocking->calculateCurrentUnitCost($alreadySoldWeight);
-        $totalCost = round((float) $sale->total_weight * $unitCost, 2);
+        $unitCost  = $this->calculateUnitCost($stocking, $alreadySoldWeight);
+        $totalCost = round((float) $sale->total_weight * $unitCost, 4);
 
         return $this->registerStockTransaction->execute(new StockTransactionDTO(
             companyId:     (string) $sale->company_id,
@@ -44,9 +45,33 @@ final readonly class RegisterBiomassOutflowAction
             totalCost:     $totalCost,
             unit:          Unit::KG,
             direction:     StockTransactionDirection::OUT,
-            supplyId:      null,
             referenceId:   (string) $sale->id,
             referenceType: StockTransactionReferenceType::SALE,
         ));
+    }
+
+    /**
+     * Custo unitario exato (R$/kg) - Regra 3.
+     *
+     * Custo total acumulado = soma de todas as entradas financeiras do stocking_id
+     * Biomassa restante = (current_quantity * average_weight) - peso_ja_vendido
+     */
+    private function calculateUnitCost(Stocking $stocking, float $alreadySoldWeight): float
+    {
+        $totalAccumulatedCost = $this->stockingRepository
+            ->totalAccumulatedCost((string) $stocking->id);
+
+        if ($totalAccumulatedCost <= 0) {
+            return 0.0;
+        }
+
+        $currentBiomass   = (float) $stocking->current_quantity * (float) $stocking->average_weight;
+        $remainingBiomass = $currentBiomass - $alreadySoldWeight;
+
+        if ($remainingBiomass <= 0) {
+            return 0.0;
+        }
+
+        return round($totalAccumulatedCost / $remainingBiomass, 6);
     }
 }

--- a/app/Application/Actions/Sale/ReopenStockingAndBatchAction.php
+++ b/app/Application/Actions/Sale/ReopenStockingAndBatchAction.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Sale;
+
+use App\Domain\Enums\BatchStatus;
+use App\Domain\Models\Batch;
+use App\Domain\Models\Stocking;
+use App\Domain\Repositories\BatchRepositoryInterface;
+use App\Domain\Repositories\StockingRepositoryInterface;
+use App\Domain\Repositories\TankRepositoryInterface;
+
+final readonly class ReopenStockingAndBatchAction
+{
+    public function __construct(
+        private StockingRepositoryInterface $stockingRepository,
+        private BatchRepositoryInterface $batchRepository,
+        private TankRepositoryInterface $tankRepository,
+    ) {
+    }
+
+    /**
+     * Reverte o encerramento de um despesca total:
+     *  1. Reabre o stocking (status → active, cleared_at → null)
+     *  2. Se o batch estava encerrado por causa deste stocking → reabre o batch
+     *  3. Se o batch foi reaberto → reabre o tank associado
+     *
+     * Chamado dentro da DB::transaction do UpdateSaleUseCase — atomicidade garantida.
+     */
+    public function execute(Stocking $stocking, string $batchId): void
+    {
+        // Passo 1: Reabre o stocking
+        $this->stockingRepository->update((string) $stocking->id, [
+            'status'    => 'active',
+            'closed_at' => null,
+        ]);
+
+        // Passo 2: Reabre o batch se estava encerrado
+        /** @var Batch $batch */
+        $batch = $this->batchRepository->findOrFail($batchId);
+
+        if ($batch->isFinished()) {
+            $this->batchRepository->update($batchId, [
+                'status' => BatchStatus::ACTIVE->value,
+            ]);
+
+            // Passo 3: Reabre o tank associado ao batch
+            $this->tankRepository->update((string) $batch->tank_id, [
+                'status' => 'active',
+            ]);
+        }
+    }
+}

--- a/app/Application/Actions/Sale/RevertBiomassOutflowAction.php
+++ b/app/Application/Actions/Sale/RevertBiomassOutflowAction.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Sale;
+
+use App\Application\Actions\Stock\RegisterStockTransactionAction;
+use App\Application\DTOs\StockTransactionDTO;
+use App\Domain\Enums\StockTransactionDirection;
+use App\Domain\Enums\StockTransactionReferenceType;
+use App\Domain\Enums\Unit;
+use App\Domain\Models\Sale;
+use App\Domain\Models\StockTransaction;
+use App\Domain\Repositories\StockTransactionRepositoryInterface;
+
+final readonly class RevertBiomassOutflowAction
+{
+    public function __construct(
+        private StockTransactionRepositoryInterface $stockTransactionRepository,
+        private RegisterStockTransactionAction $registerStockTransaction,
+    ) {
+    }
+
+    /**
+     * Estorna a baixa de biomassa gerada no momento da venda.
+     *
+     * Estratégia de estorno por contra-lançamento:
+     *  - Busca a transação de saída (direction=out, reference_type=sale, reference_id=sale_id)
+     *  - Cria uma nova transação de entrada (direction=in) com o mesmo quantity e unit_price
+     *  - Soft-delete na transação original
+     *
+     * Contra-lançamento em vez de delete direto preserva o histórico financeiro
+     * e mantém o CMV rastreável para auditorias.
+     *
+     * Se não houver transação de estoque vinculada (venda sem stocking_id),
+     * retorna null silenciosamente.
+     */
+    public function execute(Sale $sale): ?StockTransaction
+    {
+        // Busca a transação de saída original desta venda
+        $original = $this->stockTransactionRepository->findBy('reference_id', (string) $sale->id);
+
+        if (! $original instanceof StockTransaction) {
+            return null;
+        }
+
+        // Cria contra-lançamento (entrada) para neutralizar a saída
+        $reversal = $this->registerStockTransaction->execute(new StockTransactionDTO(
+            companyId:     (string) $sale->company_id,
+            quantity:      (float)  $original->quantity,
+            unitPrice:     (float)  $original->unit_price,
+            totalCost:     (float)  $original->total_cost,
+            unit:          Unit::from($original->unit),
+            direction:     StockTransactionDirection::IN,
+            supplyId:      null,
+            referenceId:   (string) $sale->id,
+            referenceType: StockTransactionReferenceType::SALE,
+        ));
+
+        // Soft-delete na transação original — mantida no histórico mas marcada como revertida
+        $this->stockTransactionRepository->delete((string) $original->id);
+
+        return $reversal;
+    }
+}

--- a/app/Application/Actions/Sale/SyncReceivableAmountAction.php
+++ b/app/Application/Actions/Sale/SyncReceivableAmountAction.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Sale;
+
+use App\Domain\Enums\FinancialTransactionStatus;
+use App\Domain\Exceptions\SaleFinanciallyLockedException;
+use App\Domain\Models\FinancialTransaction;
+use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
+use Illuminate\Support\Collection;
+
+/**
+ * Sincroniza o valor das transações financeiras vinculadas a uma venda
+ * quando a receita é alterada no update.
+ *
+ * Fluxo:
+ *  1. Busca transações com lockForUpdate via repositório.
+ *  2. Lança SaleFinanciallyLockedException se alguma não for pending.
+ *  3. Só escreve se o valor efetivamente mudou (evita UPDATE desnecessário).
+ *
+ * Chamada dentro de DB::transaction — atomicidade garantida pelo chamador.
+ *
+ * @throws SaleFinanciallyLockedException
+ */
+final readonly class SyncReceivableAmountAction
+{
+    private const float EPSILON = 0.000_01;
+
+    public function __construct(
+        private FinancialTransactionRepositoryInterface $transactionRepository,
+    ) {
+    }
+
+    /**
+     * @throws SaleFinanciallyLockedException
+     */
+    public function execute(string $saleId, float $newRevenue, float $oldRevenue): void
+    {
+        $transactions = $this->transactionRepository->findLockedBySaleId($saleId);
+
+        if ($transactions->isEmpty()) {
+            return;
+        }
+
+        $this->assertAllPending($transactions);
+
+        if (! $this->hasChanged($newRevenue, $oldRevenue)) {
+            return;
+        }
+
+        foreach ($transactions as $transaction) {
+            $this->transactionRepository->update((string) $transaction->id, [
+                'amount' => $newRevenue,
+            ]);
+        }
+    }
+
+    public function hasChanged(float $newRevenue, float $oldRevenue): bool
+    {
+        return abs($newRevenue - $oldRevenue) > self::EPSILON;
+    }
+
+    /**
+     * @param Collection<int, FinancialTransaction> $transactions
+     *
+     * @throws SaleFinanciallyLockedException
+     */
+    private function assertAllPending(Collection $transactions): void
+    {
+        foreach ($transactions as $transaction) {
+            if ($transaction->status !== FinancialTransactionStatus::PENDING) {
+                throw new SaleFinanciallyLockedException();
+            }
+        }
+    }
+}

--- a/app/Application/DTOs/BatchDistributionInputDTO.php
+++ b/app/Application/DTOs/BatchDistributionInputDTO.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\DTOs;
+
+final readonly class BatchDistributionInputDTO
+{
+    /**
+     * @param array<int, array{tankId: string, quantity: int, averageWeight: float}> $distribution
+     */
+    public function __construct(
+        public string $supplierId,
+        public string $companyId,
+        public float $totalCost,
+        public string $entryDate,
+        public string $species,
+        public string $cultivation,
+        public array $distribution,
+        public ?string $notes = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $companyId = (string) ($data['company_id'] ?? $data['companyId'] ?? '');
+
+        return new self(
+            supplierId: (string) $data['supplierId'],
+            companyId: $companyId,
+            totalCost: (float) $data['totalCost'],
+            entryDate: (string) $data['entryDate'],
+            species: (string) $data['species'],
+            cultivation: (string) $data['cultivation'],
+            distribution: $data['distribution'],
+            notes: $data['notes'] ?? null,
+        );
+    }
+
+    public function getTotalQuantity(): int
+    {
+        return array_sum(array_column($this->distribution, 'quantity'));
+    }
+}

--- a/app/Application/DTOs/BatchInputDTO.php
+++ b/app/Application/DTOs/BatchInputDTO.php
@@ -19,6 +19,9 @@ final readonly class BatchInputDTO
         public ?string $tankId,
         public string $status = 'active',
         public ?string $cultivation = null,
+        public ?string $parentGroupId = null,
+        public ?float $unitCost = null,
+        public ?float $totalCost = null,
     ) {
     }
 
@@ -44,6 +47,9 @@ final readonly class BatchInputDTO
             tankId:          (string) ($data['tank_id'] ?? $data['tankId'] ?? ''),
             status:          $data['status'] ?? 'active',
             cultivation:     $data['cultivation'] ?? null,
+            parentGroupId:   $data['parentGroupId'] ?? null,
+            unitCost:        $data['unitCost'] ?? null,
+            totalCost:       $data['totalCost'] ?? null,
         );
     }
 
@@ -59,6 +65,9 @@ final readonly class BatchInputDTO
             'tank_id'          => $this->tankId,
             'status'           => $this->status,
             'cultivation'      => $this->cultivation,
+            'parent_group_id'  => $this->parentGroupId,
+            'unit_cost'        => $this->unitCost,
+            'total_cost'       => $this->totalCost,
         ], static fn (int | string | null $v): bool => $v !== null);
     }
 }

--- a/app/Application/DTOs/ExpenseInputDTO.php
+++ b/app/Application/DTOs/ExpenseInputDTO.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\DTOs;
+
+use App\Domain\Enums\FinancialTransactionStatus;
+
+final readonly class ExpenseInputDTO
+{
+    public function __construct(
+        public string $companyId,
+        public float $amount,
+        public string $expenseDate,
+        public ?string $financialCategoryId = null,
+        public ?string $supplierId = null,
+        public ?string $costCenterId = null,
+        public ?string $description = null,
+        public ?string $notes = null,
+        public FinancialTransactionStatus $status = FinancialTransactionStatus::PENDING,
+        public ?string $paymentDate = null,
+    ) {
+    }
+
+    /**
+     * Valor total da despesa — mantém a mesma convenção de totalRevenue() na SaleInputDTO.
+     */
+    public function totalExpense(): float
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $status = isset($data['status'])
+            ? FinancialTransactionStatus::from((string) $data['status'])
+            : FinancialTransactionStatus::PENDING;
+
+        return new self(
+            companyId: (string) ($data['company_id'] ?? $data['companyId'] ?? ''),
+            amount: (float) ($data['amount'] ?? 0),
+            expenseDate: (string) (
+                $data['expense_date'] ?? $data['expenseDate'] ?? ''
+            ),
+            financialCategoryId: isset($data['financial_category_id'])
+                ? (string) $data['financial_category_id']
+                : (isset($data['financialCategoryId'])
+                    ? (string) $data['financialCategoryId']
+                    : null),
+            supplierId: isset($data['supplier_id'])
+                ? (string) $data['supplier_id']
+                : (isset($data['supplierId']) ? (string) $data['supplierId'] : null),
+            costCenterId: isset($data['cost_center_id'])
+                ? (string) $data['cost_center_id']
+                : (isset($data['costCenterId']) ? (string) $data['costCenterId'] : null),
+            description: isset($data['description'])
+                ? (string) $data['description']
+                : null,
+            notes: isset($data['notes']) ? (string) $data['notes'] : null,
+            status: $status,
+            paymentDate: isset($data['payment_date'])
+                ? (string) $data['payment_date']
+                : (isset($data['paymentDate']) ? (string) $data['paymentDate'] : null),
+        );
+    }
+}

--- a/app/Application/DTOs/HarvestDTO.php
+++ b/app/Application/DTOs/HarvestDTO.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Application\DTOs;
 
-class HarvestDTO
+/**
+ * DTO de resposta do módulo de colheita (Harvest).
+ */
+final readonly class HarvestDTO
 {
     public function __construct(
         public string $id,
@@ -14,25 +17,13 @@ class HarvestDTO
         public float $pricePerKg,
         public float $totalRevenue,
         public ?string $createdAt = null,
-        public ?string $updatedAt = null
+        public ?string $updatedAt = null,
     ) {
     }
 
-    /**
-     * @param  array<string, mixed>  $data
-     */
-    public static function fromArray(array $data): self
+    public function isEmpty(): bool
     {
-        return new self(
-            id: $data['id'],
-            batchId: $data['batch_id'],
-            harvestDate: $data['harvest_date'],
-            totalWeight: (float) $data['total_weight'],
-            pricePerKg: (float) $data['price_per_kg'],
-            totalRevenue: (float) $data['total_revenue'],
-            createdAt: $data['created_at'] ?? null,
-            updatedAt: $data['updated_at'] ?? null
-        );
+        return $this->id === '';
     }
 
     /**
@@ -50,15 +41,5 @@ class HarvestDTO
             'createdAt'    => $this->createdAt,
             'updatedAt'    => $this->updatedAt,
         ];
-    }
-
-    public function isEmpty(): bool
-    {
-        return ($this->id === '' || $this->id === '0') &&
-            ($this->batchId === '' || $this->batchId === '0') &&
-            ($this->harvestDate === '' || $this->harvestDate === '0') &&
-            ($this->totalWeight === 0.0) &&
-            $this->pricePerKg === 0.0 &&
-            $this->totalRevenue === 0.0;
     }
 }

--- a/app/Application/DTOs/HarvestSaleDTO.php
+++ b/app/Application/DTOs/HarvestSaleDTO.php
@@ -7,8 +7,15 @@ namespace App\Application\DTOs;
 use App\Domain\Enums\SaleStatus;
 
 /**
- * DTO específico para o fluxo de despesca/venda com validação biológica,
- * baixa de estoque e gestão do ciclo de vida do lote.
+ * DTO do fluxo de despesca/venda.
+ *
+ * Mudança em relação à versão anterior:
+ *   - fromArray() removido: a normalização camel/snake era responsabilidade
+ *     da Request. Aqui chega apenas o array validado (snake_case).
+ *   - stockingId é string obrigatória no construtor — a guarda de nulidade
+ *     saiu do UseCase e virou regra de validação na Request (stocking_id required).
+ *   - tolerancePercent removido: o UseCase usa constante interna (50%).
+ *     Manter o campo no DTO criava contrato falso.
  */
 final readonly class HarvestSaleDTO
 {
@@ -16,15 +23,14 @@ final readonly class HarvestSaleDTO
         public string $companyId,
         public string $clientId,
         public string $batchId,
+        public string $stockingId,
         public float $totalWeight,
         public float $pricePerKg,
         public string $saleDate,
         public bool $isHarvestTotal,
-        public ?string $stockingId = null,
+        public SaleStatus $status,
         public ?string $financialCategoryId = null,
-        public SaleStatus $status = SaleStatus::PENDING,
         public ?string $notes = null,
-        public float $tolerancePercent = 5.0,
         public bool $needsInvoice = false,
     ) {
     }
@@ -35,42 +41,35 @@ final readonly class HarvestSaleDTO
     }
 
     /**
-     * Upper biomass limit including the configured tolerance margin.
-     * Example: if biomass = 1000 kg and tolerancePercent = 5, limit = 1050 kg.
-     */
-    public function biomassLimitWithTolerance(float $availableBiomass): float
-    {
-        return $availableBiomass * (1 + $this->tolerancePercent / 100);
-    }
-
-    /**
+     * Constrói o DTO a partir do array validado e normalizado pela SaleStoreRequest.
+     * Todas as chaves são snake_case — sem fallback camelCase.
+     *
      * @param array<string, mixed> $data
      */
-    public static function fromArray(array $data): self
+    public static function fromValidated(array $data): self
     {
         return new self(
-            companyId:           (string) ($data['company_id'] ?? $data['companyId'] ?? ''),
-            clientId:            (string) ($data['client_id'] ?? $data['clientId'] ?? ''),
-            batchId:             (string) ($data['batch_id'] ?? $data['batchId'] ?? ''),
-            totalWeight:         (float) ($data['total_weight'] ?? $data['totalWeight'] ?? 0),
-            pricePerKg:          (float) ($data['price_per_kg'] ?? $data['pricePerKg'] ?? 0),
-            saleDate:            (string) ($data['sale_date'] ?? $data['saleDate'] ?? ''),
-            isHarvestTotal:      (bool) ($data['is_total_harvest'] ?? $data['isHarvestTotal'] ?? false),
-            stockingId:          isset($data['stocking_id']) ? (string) $data['stocking_id']
-                               : (isset($data['stockingId']) ? (string) $data['stockingId'] : null),
-            financialCategoryId: isset($data['financial_category_id']) ? (string) $data['financial_category_id']
-                               : (isset($data['financialCategoryId']) ? (string) $data['financialCategoryId'] : null),
+            companyId:           (string) ($data['company_id'] ?? ''),
+            clientId:            (string)  $data['client_id'],
+            batchId:             (string)  $data['batch_id'],
+            stockingId:          (string)  $data['stocking_id'],
+            totalWeight:         (float)   $data['total_weight'],
+            pricePerKg:          (float)   $data['price_per_kg'],
+            saleDate:            (string)  $data['sale_date'],
+            isHarvestTotal:      (bool)   ($data['is_total_harvest'] ?? false),
             status:              isset($data['status'])
-                               ? SaleStatus::from((string) $data['status'])
-                               : SaleStatus::PENDING,
+                                     ? SaleStatus::from((string) $data['status'])
+                                     : SaleStatus::PENDING,
+            financialCategoryId: isset($data['financial_category_id'])
+                                     ? (string) $data['financial_category_id']
+                                     : null,
             notes:               isset($data['notes']) ? (string) $data['notes'] : null,
-            tolerancePercent:    (float) ($data['tolerance_percent'] ?? $data['tolerancePercent'] ?? 5.0),
-            needsInvoice:        (bool) ($data['needs_invoice'] ?? $data['needsInvoice'] ?? false),
+            needsInvoice:        (bool) ($data['needs_invoice'] ?? false),
         );
     }
 
     /**
-     * Converts this DTO to a SaleInputDTO for persistence via SaleRepository.
+     * Converte para SaleInputDTO para persistência via SaleRepository.
      */
     public function toSaleInputDTO(): SaleInputDTO
     {

--- a/app/Application/DTOs/SaleInputDTO.php
+++ b/app/Application/DTOs/SaleInputDTO.php
@@ -20,6 +20,7 @@ final readonly class SaleInputDTO
         public SaleStatus $status = SaleStatus::PENDING,
         public ?string $notes = null,
         public bool $isHarvestTotal = false,
+        public bool $requiresInvoice = false,
     ) {
     }
 
@@ -28,17 +29,15 @@ final readonly class SaleInputDTO
         return round($this->totalWeight * $this->pricePerKg, 2);
     }
 
-    /**
-     * @param array<string, mixed> $data
-     */
+    /** @param array<string, mixed> $data */
     public static function fromArray(array $data): self
     {
         return new self(
             companyId:           (string) ($data['company_id'] ?? $data['companyId'] ?? ''),
             clientId:            (string) ($data['client_id'] ?? $data['clientId'] ?? ''),
             batchId:             (string) ($data['batch_id'] ?? $data['batchId'] ?? ''),
-            totalWeight:         (float) ($data['total_weight'] ?? $data['totalWeight'] ?? 0),
-            pricePerKg:          (float) ($data['price_per_kg'] ?? $data['pricePerKg'] ?? 0),
+            totalWeight:         (float)  ($data['total_weight'] ?? $data['totalWeight'] ?? 0),
+            pricePerKg:          (float)  ($data['price_per_kg'] ?? $data['pricePerKg'] ?? 0),
             saleDate:            (string) ($data['sale_date'] ?? $data['saleDate'] ?? ''),
             stockingId:          isset($data['stocking_id']) ? (string) $data['stocking_id']
                                : (isset($data['stockingId']) ? (string) $data['stockingId'] : null),
@@ -49,6 +48,7 @@ final readonly class SaleInputDTO
                                : SaleStatus::PENDING,
             notes:               isset($data['notes']) ? (string) $data['notes'] : null,
             isHarvestTotal:      (bool) ($data['is_total_harvest'] ?? $data['isHarvestTotal'] ?? false),
+            requiresInvoice:     (bool) ($data['requires_invoice'] ?? $data['requiresInvoice'] ?? false),
         );
     }
 }

--- a/app/Application/DTOs/StockTransactionDTO.php
+++ b/app/Application/DTOs/StockTransactionDTO.php
@@ -16,7 +16,6 @@ use App\Domain\Enums\Unit;
  * @property Unit $unit
  * @property StockTransactionDirection $direction
  * @property string|null $supplyId
- * @property string|null $supplierId
  * @property string|null $referenceId
  * @property StockTransactionReferenceType|null $referenceType
  */
@@ -30,7 +29,6 @@ final readonly class StockTransactionDTO
         public Unit $unit,
         public StockTransactionDirection $direction,
         public ?string $supplyId = null,
-        public ?string $supplierId = null,
         public ?string $referenceId = null,
         public ?StockTransactionReferenceType $referenceType = null,
     ) {
@@ -49,7 +47,6 @@ final readonly class StockTransactionDTO
             'unit'           => $this->unit->value,
             'direction'      => $this->direction->value,
             'supply_id'      => $this->supplyId,
-            'supplier_id'    => $this->supplierId,
             'reference_id'   => $this->referenceId,
             'reference_type' => $this->referenceType?->value,
         ], static fn (mixed $v): bool => $v !== null);

--- a/app/Application/Listeners/GenerateStockingHistory.php
+++ b/app/Application/Listeners/GenerateStockingHistory.php
@@ -5,25 +5,34 @@ declare(strict_types=1);
 namespace App\Application\Listeners;
 
 use App\Domain\Enums\StockingHistoryEvent;
-use App\Domain\Enums\StockingStatus;
 use App\Domain\Events\FeedingCreated;
 use App\Domain\Events\MortalityRecorded;
 use App\Domain\Events\SaleProcessed;
 use App\Domain\Models\Stocking;
 use App\Domain\Models\StockingHistory;
+use App\Domain\Repositories\StockingRepositoryInterface;
 use Illuminate\Support\Str;
 
 /**
- * Single listener that handles all three domain events and creates the
- * corresponding StockingHistory records automatically.
+ * Listener que cria registros de histórico do stocking para os três eventos de domínio.
  *
- * Registered for: FeedingCreated | MortalityRecorded | SaleProcessed
+ * Mudança em relação à versão anterior:
+ *  - findActiveStockingByBatch() usava Stocking::query() diretamente.
+ *    Agora usa StockingRepositoryInterface::findByBatchId() — mantém
+ *    a camada de infraestrutura encapsulada e facilita testes.
+ *
+ * Registrado para: FeedingCreated | MortalityRecorded | SaleProcessed
  */
-final class GenerateStockingHistory
+final readonly class GenerateStockingHistory
 {
+    public function __construct(
+        private StockingRepositoryInterface $stockingRepository,
+    ) {
+    }
+
     public function handleFeedingCreated(FeedingCreated $event): void
     {
-        $stocking = $this->findActiveStockingByBatch($event->feeding->batch_id);
+        $stocking = $this->stockingRepository->findByBatchId($event->feeding->batch_id);
 
         if (! $stocking instanceof Stocking) {
             return;
@@ -45,7 +54,7 @@ final class GenerateStockingHistory
 
     public function handleMortalityRecorded(MortalityRecorded $event): void
     {
-        $stocking = $this->findActiveStockingByBatch($event->mortality->batch_id);
+        $stocking = $this->stockingRepository->findByBatchId($event->mortality->batch_id);
 
         if (! $stocking instanceof Stocking) {
             return;
@@ -70,7 +79,6 @@ final class GenerateStockingHistory
     {
         $sale = $event->sale;
 
-        // Only generate stocking history when the sale is linked to a specific stocking
         if ($sale->stocking_id === null) {
             return;
         }
@@ -88,17 +96,5 @@ final class GenerateStockingHistory
                 $sale->total_revenue,
             ),
         ]);
-    }
-
-    /**
-     * Finds the latest active stocking for a given batch.
-     * Returns null if no active stocking exists (feeding/mortality without stocking context).
-     */
-    private function findActiveStockingByBatch(string $batchId): ?Stocking
-    {
-        return Stocking::where('batch_id', $batchId)
-            ->where('status', StockingStatus::ACTIVE)
-            ->latest('stocking_date')
-            ->first();
     }
 }

--- a/app/Application/Services/Client/ClientCreditService.php
+++ b/app/Application/Services/Client/ClientCreditService.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Services\Client;
+
+use App\Domain\Exceptions\ClientCreditLimitExceededException;
+use App\Domain\Models\Client;
+use App\Domain\Repositories\ClientRepositoryInterface;
+
+final readonly class ClientCreditService
+{
+    public function __construct(
+        private ClientRepositoryInterface $clientRepository,
+    ) {
+    }
+
+    public function guardCreditLimit(Client $client, float $saleAmount): void
+    {
+        if ($client->credit_limit === null) {
+            return;
+        }
+
+        $creditLimit = (float) $client->credit_limit;
+
+        if ($creditLimit < $saleAmount) {
+            throw new ClientCreditLimitExceededException(
+                clientName:        $client->name,
+                creditLimit:     $creditLimit,
+                currentExposure: 0,
+                newSaleAmount:   $saleAmount,
+            );
+        }
+
+        $currentExposure = $this->clientRepository->getPendingObligations($client->id);
+
+        if (($currentExposure + $saleAmount) > $creditLimit) {
+            throw new ClientCreditLimitExceededException(
+                clientName:        $client->name,
+                creditLimit:     $creditLimit,
+                currentExposure: $currentExposure,
+                newSaleAmount:   $saleAmount,
+            );
+        }
+    }
+}

--- a/app/Application/Services/Sale/SaleRevenueCalculator.php
+++ b/app/Application/Services/Sale/SaleRevenueCalculator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Services\Sale;
+
+use App\Domain\Models\Sale;
+use App\Domain\ValueObjects\SaleAttributes;
+
+/**
+ * Application Service: cálculo de receita total de uma venda.
+ *
+ * Regra: total_revenue = total_weight × price_per_kg (arredondado a 2 casas).
+ *
+ * Centraliza a fórmula que estava duplicada em UpdateSaleUseCase e UpdateSaleAction.
+ * Sem dependências externas — é puro PHP.
+ *
+ * Namespace: Application\Services (padrão do projeto).
+ */
+final class SaleRevenueCalculator
+{
+    private const int PRECISION = 2;
+
+    /**
+     * Calcula a receita considerando o payload do update e o estado atual da venda.
+     * Campos ausentes em $attributes são complementados pelo estado atual de $sale.
+     */
+    public function calculate(Sale $sale, SaleAttributes $attributes): float
+    {
+        $weight = $attributes->resolveWeight($sale);
+        $price  = $attributes->resolvePrice($sale);
+
+        return round($weight * $price, self::PRECISION);
+    }
+
+    /**
+     * Calcula direto de peso e preço explícitos.
+     */
+    public function calculateFrom(float $weight, float $pricePerKg): float
+    {
+        return round($weight * $pricePerKg, self::PRECISION);
+    }
+}

--- a/app/Application/UseCases/Batch/DistributeBatchUseCase.php
+++ b/app/Application/UseCases/Batch/DistributeBatchUseCase.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\Batch;
+
+use App\Application\Actions\Batch\CreateDistributedBatchesAction;
+use App\Application\Actions\Batch\ValidateTanksForDistributionAction;
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Application\DTOs\BatchDistributionInputDTO;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final readonly class DistributeBatchUseCase
+{
+    public function __construct(
+        private ValidateTanksForDistributionAction $validateTanks,
+        private CreateDistributedBatchesAction $createBatches,
+        private CompanyResolverInterface $companyResolver,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return Collection<int, \App\Domain\Models\Batch>
+     *
+     * @throws \App\Domain\Exceptions\TankAlreadyHasActiveBatchException
+     * @throws \Throwable
+     */
+    public function execute(array $data): Collection
+    {
+        $data['company_id'] = $this->companyResolver->resolve(
+            hint: $data['company_id'] ?? $data['companyId'] ?? null,
+        );
+        $input = BatchDistributionInputDTO::fromArray($data);
+
+        $this->validateTanks->execute($input);
+
+        return DB::transaction(fn (): \Illuminate\Support\Collection => $this->createBatches->execute($input));
+    }
+}

--- a/app/Application/UseCases/FinancialCategory/ListFinancialCategoriesUseCase.php
+++ b/app/Application/UseCases/FinancialCategory/ListFinancialCategoriesUseCase.php
@@ -21,7 +21,7 @@ final readonly class ListFinancialCategoriesUseCase
      */
     public function execute(array $filters = []): PaginationInterface
     {
-        $filters['company_id'] = $this->companyResolver->resolve();
+        $filters['companyId'] = $this->companyResolver->resolve();
 
         return $this->repository->paginate($filters);
     }

--- a/app/Application/UseCases/Sale/CancelSaleUseCase.php
+++ b/app/Application/UseCases/Sale/CancelSaleUseCase.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\Sale;
+
+use App\Application\Actions\Sale\CancelSaleReceivablesAction;
+use App\Application\Actions\Sale\ReopenStockingAndBatchAction;
+use App\Application\Actions\Sale\RevertBiomassOutflowAction;
+use App\Domain\Enums\SaleStatus;
+use App\Domain\Models\Sale;
+use App\Domain\Models\Stocking;
+use App\Domain\Repositories\SaleRepositoryInterface;
+use App\Domain\Repositories\StockingRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+
+final readonly class CancelSaleUseCase
+{
+    public function __construct(
+        private SaleRepositoryInterface $saleRepository,
+        private StockingRepositoryInterface $stockingRepository,
+        private CancelSaleReceivablesAction $cancelReceivables,
+        private RevertBiomassOutflowAction $revertBiomassOutflow,
+        private ReopenStockingAndBatchAction $reopenStockingAndBatch,
+    ) {
+    }
+
+    /**
+     * Desfaz uma venda de forma atômica revertendo todos os efeitos colaterais:
+     *
+     *   Passo 1 — Trava financeira
+     *             Cancela os Contas a Receber (pending/overdue → cancelled).
+     *             Se algum estiver pago → SaleFinanciallyLockedException.
+     *
+     *   Passo 2 — Estorno de biomassa
+     *             Cria contra-lançamento IN no livro-razão e soft-delete
+     *             na transação OUT original, restaurando o saldo do stocking.
+     *
+     *   Passo 3 — Reabertura de ciclo de vida
+     *             Se a venda era is_total_harvest=true e fechou o stocking/batch,
+     *             reabre ambos (e o tank associado, se necessário).
+     *
+     *   Passo 4 — Soft delete da venda
+     */
+    public function execute(string $id): void
+    {
+        DB::transaction(function () use ($id): void {
+            // Lock pessimista — evita deleção concorrente ou edição simultânea
+            /** @var Sale $sale */
+            $sale = $this->saleRepository->findOrFailLocked($id);
+
+            // ── Passo 1: Cancela recebíveis ───────────────────────────────────
+            // Verificação ANTES de qualquer outra ação — se estiver pago, para aqui
+            $this->cancelReceivables->execute((string) $sale->id);
+
+            // ── Passo 2: Estorno de biomassa ──────────────────────────────────
+            // Cria contra-lançamento IN e soft-delete no OUT original
+            $this->revertBiomassOutflow->execute($sale);
+
+            // ── Passo 3: Reabertura do ciclo de vida ──────────────────────────
+            if ($sale->stocking_id !== null && (bool) $sale->is_total_harvest) {
+                $stocking = $this->resolveLockedStocking((string) $sale->stocking_id);
+
+                // Só reabre se ainda estiver fechado
+                // (outra venda posterior pode já ter reaberto)
+                if ($stocking->isClosed()) {
+                    $this->reopenStockingAndBatch->execute(
+                        $stocking,
+                        (string) $sale->batch_id,
+                    );
+                }
+            }
+
+            // ── Passo 4: Cancela a venda ──────────────────────────────────────
+            $this->saleRepository->update((string) $sale->id, [
+                'status' => SaleStatus::CANCELLED,
+            ]);
+        });
+    }
+
+    /**
+     * Busca o stocking com lock pessimista via repositório.
+     */
+    private function resolveLockedStocking(string $stockingId): Stocking
+    {
+        return $this->stockingRepository->findOrFailLocked($stockingId);
+    }
+}

--- a/app/Application/UseCases/Sale/DeleteSaleUseCase.php
+++ b/app/Application/UseCases/Sale/DeleteSaleUseCase.php
@@ -4,22 +4,31 @@ declare(strict_types=1);
 
 namespace App\Application\UseCases\Sale;
 
+use App\Domain\Enums\SaleStatus;
+use App\Domain\Exceptions\InvalidSaleStatusTransitionException;
 use App\Domain\Repositories\SaleRepositoryInterface;
 use Illuminate\Support\Facades\DB;
 
 final readonly class DeleteSaleUseCase
 {
     public function __construct(
-        private SaleRepositoryInterface $repository,
+        private SaleRepositoryInterface $saleRepository,
     ) {
     }
 
     public function execute(string $id): void
     {
-        $this->repository->findOrFail($id);
-
         DB::transaction(function () use ($id): void {
-            $this->repository->delete($id);
+            $sale = $this->saleRepository->findOrFail($id);
+
+            if (! $sale->status->isCancelled()) {
+                throw new InvalidSaleStatusTransitionException(
+                    from: $sale->status,
+                    to:   SaleStatus::CANCELLED,
+                );
+            }
+
+            $this->saleRepository->delete($id);
         });
     }
 }

--- a/app/Application/UseCases/Sale/ListSalesUseCase.php
+++ b/app/Application/UseCases/Sale/ListSalesUseCase.php
@@ -16,9 +16,7 @@ final readonly class ListSalesUseCase
     ) {
     }
 
-    /**
-     * @param array<string, mixed> $filters
-     */
+    /** @param array<string, mixed> $filters */
     public function execute(array $filters = []): PaginationInterface
     {
         $filters['company_id'] = $this->companyResolver->resolve();

--- a/app/Application/UseCases/Sale/ProcessHarvestSaleUseCase.php
+++ b/app/Application/UseCases/Sale/ProcessHarvestSaleUseCase.php
@@ -7,150 +7,128 @@ namespace App\Application\UseCases\Sale;
 use App\Application\Actions\Client\GuardClientCreditAction;
 use App\Application\Actions\Sale\GenerateReceivableAction;
 use App\Application\Actions\Sale\GuardBiomassAction;
+use App\Application\Actions\Sale\GuardClientFiscalDataAction;
+use App\Application\Actions\Sale\HarvestLifecycleAction;
 use App\Application\Actions\Sale\RegisterBiomassOutflowAction;
 use App\Application\Contracts\CompanyResolverInterface;
 use App\Application\DTOs\HarvestSaleDTO;
 use App\Domain\Events\SaleProcessed;
-use App\Domain\Exceptions\ClientMissingFiscalDataException;
 use App\Domain\Exceptions\ClosedStockingException;
-use App\Domain\Models\Client;
 use App\Domain\Models\Sale;
 use App\Domain\Models\Stocking;
 use App\Domain\Repositories\SaleRepositoryInterface;
+use App\Domain\Repositories\StockingRepositoryInterface;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Motor principal de despesca e venda.
+ * Orquestra o fluxo completo de despesca e venda.
  *
- * Dentro de um único DB::transaction:
- *   1. Valida que a estocagem não está encerrada.
- *   2. Valida biomassa disponível com margem de tolerância.
- *   3. Persiste a venda.
- *   4. Registra baixa no livro-razão (direction=out) com custo unitário acumulado.
- *   5. Encerra a estocagem quando is_total_harvest = true.
- *   6. Gera "Contas a Receber" (FinancialTransaction PENDING, reference_type=sale).
+ * Regras de negócio aplicadas (em ordem):
+ *   1. stocking_id obrigatório — garantido pela SaleStoreRequest (required).
+ *   2. Stocking não pode estar fechado.
+ *   3. Dados fiscais do cliente (se needs_invoice = true).
+ *   4. Limite de crédito do cliente.
+ *   5. Biomassa disponível com tolerância de 50% (constante de domínio).
+ *   6. Persistência da venda.
+ *   7. Baixa de biomassa com CMV exato (RegisterBiomassOutflowAction).
+ *   8. Ciclo de vida stocking/batch se is_total_harvest = true (HarvestLifecycleAction).
+ *   9. Geração de Contas a Receber (GenerateReceivableAction).
+ *  10. Evento SaleProcessed disparado após commit → GenerateStockingHistory.
+ *
+ * Mudanças em relação à versão anterior:
+ *   - Stocking carregado via StockingRepositoryInterface (não mais Stocking::findOrFail diretamente).
+ *   - CloseStockingAndBatchAction substituída por HarvestLifecycleAction (unificação create/update).
+ *   - HarvestSaleDTO construído com fromValidated() em vez de fromArray() — normalização feita na Request.
+ *   - StockingRequiredException removida: stocking_id é `required` na Request, nunca chega null aqui.
+ *   - company_id resolvido antes de construir o DTO, mantendo o DTO sem dependência do resolver.
  */
 final readonly class ProcessHarvestSaleUseCase
 {
+    /**
+     * Regra 5: tolerância máxima acima da biomassa estimada permitida na despesca.
+     * Constante de domínio — não lida do payload.
+     */
+    private const float BIOMASS_TOLERANCE_PERCENT = 50.0;
+
     public function __construct(
-        private SaleRepositoryInterface $repository,
+        private SaleRepositoryInterface $saleRepository,
+        private StockingRepositoryInterface $stockingRepository,
         private CompanyResolverInterface $companyResolver,
+        private GuardClientFiscalDataAction $guardFiscalData,
+        private GuardClientCreditAction $guardClientCredit,
         private GuardBiomassAction $guardBiomass,
         private RegisterBiomassOutflowAction $registerOutflow,
+        private HarvestLifecycleAction $harvestLifecycle,
         private GenerateReceivableAction $generateReceivable,
-        private GuardClientCreditAction $guardClientCredit,
     ) {
     }
 
     /**
-     * @param array<string, mixed> $data Dados validados pelo FormRequest
+     * @param array<string, mixed> $data Array validado e normalizado pela SaleStoreRequest.
+     *
+     * @throws ClosedStockingException
+     * @throws \App\Domain\Exceptions\ClientMissingFiscalDataException
+     * @throws \App\Domain\Exceptions\ClientCreditLimitExceededException
+     * @throws \App\Domain\Exceptions\InsufficientBiomassException
      */
     public function execute(array $data): Sale
     {
         $data['company_id'] = $this->companyResolver->resolve(
-            hint: $data['company_id'] ?? $data['companyId'] ?? null,
+            hint: $data['company_id'] ?? null,
         );
 
-        $dto = HarvestSaleDTO::fromArray($data);
+        $dto = HarvestSaleDTO::fromValidated($data);
 
-        return DB::transaction(function () use ($dto): Sale {
-            if ($dto->stockingId !== null) {
-                return $this->processWithStocking($dto);
-            }
-
-            return $this->processWithoutStocking($dto);
-        });
+        return DB::transaction(fn (): Sale => $this->process($dto));
     }
 
-    /**
-     * Fluxo completo: validação de biomassa → venda → baixa → ciclo de vida → recebível.
-     */
-    private function processWithStocking(HarvestSaleDTO $dto): Sale
+    private function process(HarvestSaleDTO $dto): Sale
     {
-        /** @var Stocking $stocking */
-        $stocking = Stocking::findOrFail($dto->stockingId);
+        // ── 1. Carrega e valida o stocking ────────────────────────────────────
+        $stocking = $this->stockingRepository->findOrFail($dto->stockingId);
 
         if ($stocking->isClosed()) {
             throw new ClosedStockingException($stocking->id);
         }
 
-        // Passo 0: Valida dados fiscais se emissão de nota fiscal solicitada
-        $this->guardClientFiscalData($dto);
-
-        // Passo 1a: Valida limite de crédito do cliente
+        // ── 2. Validações pré-persistência (sem escrita no banco) ─────────────
+        $this->guardFiscalData->execute($dto->clientId, $dto->needsInvoice);
         $this->guardClientCredit->execute($dto->clientId, $dto->totalRevenue());
-
-        // Passo 1b: Valida biomassa com tolerância configurável
         $this->guardBiomass->executeWithTolerance(
             stocking:         $stocking,
             requestedWeight:  $dto->totalWeight,
-            tolerancePercent: $dto->tolerancePercent,
+            tolerancePercent: self::BIOMASS_TOLERANCE_PERCENT,
         );
 
-        // Passo 2: Persiste a venda
-        $sale = $this->repository->create($dto->toSaleInputDTO());
+        // ── 3. Persiste a venda ───────────────────────────────────────────────
+        $sale = $this->saleRepository->create($dto->toSaleInputDTO());
 
-        // Passo 3: Baixa de biomassa no livro-razão
-        // Calcula peso já vendido ANTES desta venda (exclui a atual do cálculo)
-        $alreadySoldWeight = $this->repository->soldWeightByStocking(
-            stockingId:    $stocking->id,
-            excludeSaleId: $sale->id,
+        // ── 4. Baixa de biomassa com CMV exato (Regra 3) ─────────────────────
+        // Peso já vendido ANTES desta venda (exclui a atual para não contaminar o CMV)
+        $alreadySoldWeight = $this->saleRepository->soldWeightByStocking(
+            stockingId:    $dto->stockingId,
+            excludeSaleId: (string) $sale->id,
         );
 
         $this->registerOutflow->execute($stocking, $sale, $alreadySoldWeight);
 
-        // Passo 4: Encerra a estocagem se for despesca total
+        // ── 5. Ciclo de vida stocking/batch (Regra 4) ─────────────────────────
+        // HarvestLifecycleAction é idempotente: oldHarvest=false, newHarvest=dto->isHarvestTotal
         if ($dto->isHarvestTotal) {
-            $stocking->markAsClosed();
+            $this->harvestLifecycle->apply(
+                stocking:          $stocking,
+                oldIsTotalHarvest: false,
+                newIsTotalHarvest: true,
+                batchId:           $dto->batchId,
+            );
         }
 
-        // Passo 5: Gera Contas a Receber
+        // ── 6. Contas a Receber (Regra 5) ─────────────────────────────────────
         $this->generateReceivable->execute($dto->toSaleInputDTO(), $sale);
 
-        // Passo 6: Dispara evento para gerar histórico automático no lote
+        // Disparado após commit — listener GenerateStockingHistory cria o histórico
         SaleProcessed::dispatch($sale);
 
         return $sale;
-    }
-
-    /**
-     * Venda simples sem estocagem vinculada: persiste + recebível apenas.
-     */
-    private function processWithoutStocking(HarvestSaleDTO $dto): Sale
-    {
-        $this->guardClientFiscalData($dto);
-        $this->guardClientCredit->execute($dto->clientId, $dto->totalRevenue());
-
-        $sale = $this->repository->create($dto->toSaleInputDTO());
-
-        $this->generateReceivable->execute($dto->toSaleInputDTO(), $sale);
-
-        // Dispara mesmo sem stocking; o listener ignora quando stocking_id é null
-        SaleProcessed::dispatch($sale);
-
-        return $sale;
-    }
-
-    /**
-     * Se needs_invoice for true, exige que o cliente tenha document_number e address.
-     *
-     * @throws ClientMissingFiscalDataException
-     */
-    private function guardClientFiscalData(HarvestSaleDTO $dto): void
-    {
-        if (! $dto->needsInvoice) {
-            return;
-        }
-
-        /** @var Client|null $client */
-        $client = Client::find($dto->clientId);
-
-        if (
-            $client === null
-            || empty($client->document_number)
-            || empty($client->address)
-        ) {
-            throw new ClientMissingFiscalDataException($dto->clientId);
-        }
     }
 }

--- a/app/Application/UseCases/Sale/UpdateSaleUseCase.php
+++ b/app/Application/UseCases/Sale/UpdateSaleUseCase.php
@@ -5,93 +5,116 @@ declare(strict_types=1);
 namespace App\Application\UseCases\Sale;
 
 use App\Application\Actions\Sale\GuardBiomassAction;
-use App\Domain\Enums\SaleStatus;
+use App\Application\Actions\Sale\HarvestLifecycleAction;
+use App\Application\Actions\Sale\SyncReceivableAmountAction;
+use App\Application\Services\Sale\SaleRevenueCalculator;
 use App\Domain\Models\Sale;
 use App\Domain\Models\Stocking;
 use App\Domain\Repositories\SaleRepositoryInterface;
+use App\Domain\Repositories\StockingRepositoryInterface;
+use App\Domain\ValueObjects\SaleAttributes;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * Orquestra a atualização de uma venda dentro de uma transação única.
+ *
+ * Campos editáveis: total_weight, price_per_kg, sale_date, is_total_harvest, status, notes.
+ * Campos imutáveis: client_id, batch_id, stocking_id (garantido pela SaleUpdateRequest).
+ *
+ * Responsabilidade deste UseCase: coordenar a sequência correta de ações,
+ * garantir a transação e devolver o modelo atualizado.
+ *
+ * Regras delegadas:
+ *  - Biomassa          → GuardBiomassAction
+ *  - Ciclo de vida     → HarvestLifecycleAction
+ *  - Sync financeiro   → SyncReceivableAmountAction
+ *  - Cálculo receita   → SaleRevenueCalculator
+ *  - Atributos patch   → SaleAttributes (Value Object)
+ */
 final readonly class UpdateSaleUseCase
 {
     public function __construct(
-        private SaleRepositoryInterface $repository,
+        private SaleRepositoryInterface $saleRepository,
+        private StockingRepositoryInterface $stockingRepository,
         private GuardBiomassAction $guardBiomass,
+        private HarvestLifecycleAction $harvestLifecycle,
+        private SyncReceivableAmountAction $syncReceivable,
+        private SaleRevenueCalculator $revenueCalculator,
     ) {
     }
 
     /**
-     * @param array<string, mixed> $data Dados validados pelo FormRequest
+     * @param array<string, mixed> $data Array validado e normalizado pela SaleUpdateRequest.
+     *
+     * @throws \App\Domain\Exceptions\InsufficientBiomassException
+     * @throws \App\Domain\Exceptions\SaleFinanciallyLockedException
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function execute(string $id, array $data): Sale
     {
-        $sale = $this->repository->findOrFail($id);
+        return DB::transaction(function () use ($id, $data): Sale {
+            // ── 1. Carrega entidades com locks pessimistas ────────────────────
+            $sale       = $this->saleRepository->findOrFailLocked($id);
+            $stocking   = $this->resolveLockedStocking($sale);
+            $attributes = SaleAttributes::fromValidatedData($data);
 
-        $attributes = $this->buildAttributes($sale, $data);
+            // ── 2. Valida biomassa (só se o peso aumentou) ────────────────────
+            $this->guardBiomassIfNeeded($sale, $stocking, $attributes);
 
-        return DB::transaction(
-            fn (): Sale => $this->repository->update($id, $attributes)
-        );
-    }
-
-    /**
-     * Mescla o estado atual da venda com o patch recebido.
-     * Campos ausentes em $data não são sobrescritos.
-     * Revalida biomassa quando total_weight muda.
-     *
-     * @param array<string, mixed> $data
-     * @return array<string, mixed>
-     */
-    private function buildAttributes(Sale $sale, array $data): array
-    {
-        $attributes = [];
-
-        if (array_key_exists('client_id', $data)) {
-            $attributes['client_id'] = $data['client_id'];
-        }
-
-        if (array_key_exists('total_weight', $data)) {
-            $newWeight  = (float) $data['total_weight'];
-            $stockingId = $data['stocking_id'] ?? $sale->stocking_id;
-
-            // Revalida biomassa excluindo o peso já comprometido por esta venda
-            if ($stockingId !== null) {
-                /** @var Stocking $stocking */
-                $stocking = Stocking::findOrFail((string) $stockingId);
-
-                $this->guardBiomass->execute(
-                    stocking:        $stocking,
-                    requestedWeight: $newWeight,
-                    excludeSaleId:   $sale->id,
+            // ── 3. Ciclo de vida stocking/batch ───────────────────────────────
+            if ($stocking instanceof Stocking) {
+                $this->harvestLifecycle->apply(
+                    stocking:          $stocking,
+                    oldIsTotalHarvest: (bool) $sale->is_total_harvest,
+                    newIsTotalHarvest: $attributes->resolveIsTotalHarvest($sale),
+                    batchId:           (string) $sale->batch_id,
                 );
             }
 
-            $attributes['total_weight'] = $newWeight;
+            // ── 4. Receita e sincronização financeira ─────────────────────────
+            $newRevenue = $this->revenueCalculator->calculate($sale, $attributes);
+            $oldRevenue = round((float) $sale->total_revenue, 2);
+
+            $this->syncReceivable->execute((string) $sale->id, $newRevenue, $oldRevenue);
+
+            if ($this->syncReceivable->hasChanged($newRevenue, $oldRevenue)) {
+                $attributes = $attributes->withRevenue($newRevenue);
+            }
+
+            // ── 5. Persistência ───────────────────────────────────────────────
+            if ($attributes->isEmpty()) {
+                return $this->saleRepository->findOrFail($id);
+            }
+
+            return $this->saleRepository->update($id, $attributes->toArray());
+        });
+    }
+
+    // ── Privados ──────────────────────────────────────────────────────────────
+
+    private function resolveLockedStocking(Sale $sale): ?Stocking
+    {
+        if ($sale->stocking_id === null) {
+            return null;
         }
 
-        if (array_key_exists('price_per_kg', $data)) {
-            $attributes['price_per_kg'] = (float) $data['price_per_kg'];
+        return $this->stockingRepository->findOrFailLocked((string) $sale->stocking_id);
+    }
+
+    private function guardBiomassIfNeeded(
+        Sale $sale,
+        ?Stocking $stocking,
+        SaleAttributes $attributes,
+    ): void {
+        if (! $stocking instanceof Stocking || ! $attributes->has('total_weight')) {
+            return;
         }
 
-        // Recalcula total_revenue se peso ou preço mudaram
-        if (isset($attributes['total_weight']) || isset($attributes['price_per_kg'])) {
-            $weight = $attributes['total_weight'] ?? (float) $sale->total_weight;
-            $price  = $attributes['price_per_kg'] ?? (float) $sale->price_per_kg;
+        $newWeight = $attributes->resolveWeight($sale);
+        $oldWeight = (float) $sale->total_weight;
 
-            $attributes['total_revenue'] = round($weight * $price, 2);
+        if ($newWeight > $oldWeight) {
+            $this->guardBiomass->execute($stocking, $newWeight, (string) $sale->id);
         }
-
-        if (array_key_exists('sale_date', $data)) {
-            $attributes['sale_date'] = $data['sale_date'];
-        }
-
-        if (array_key_exists('status', $data)) {
-            $attributes['status'] = SaleStatus::from((string) $data['status'])->value;
-        }
-
-        if (array_key_exists('notes', $data)) {
-            $attributes['notes'] = $data['notes'];
-        }
-
-        return $attributes;
     }
 }

--- a/app/Domain/Enums/SaleStatus.php
+++ b/app/Domain/Enums/SaleStatus.php
@@ -13,9 +13,9 @@ enum SaleStatus: string
     public function label(): string
     {
         return match ($this) {
-            self::PENDING   => 'Pending',
-            self::CONFIRMED => 'Confirmed',
-            self::CANCELLED => 'Cancelled',
+            self::PENDING   => 'Pendente',
+            self::CONFIRMED => 'Confirmada',
+            self::CANCELLED => 'Cancelada',
         };
     }
 

--- a/app/Domain/Exceptions/ClientCreditLimitExceededException.php
+++ b/app/Domain/Exceptions/ClientCreditLimitExceededException.php
@@ -8,12 +8,12 @@ use RuntimeException;
 
 final class ClientCreditLimitExceededException extends RuntimeException
 {
-    public function __construct(string $clientId, float $creditLimit, float $currentExposure, float $newSaleAmount)
+    public function __construct(string $clientName, float $creditLimit, float $currentExposure, float $newSaleAmount)
     {
         $total = $currentExposure + $newSaleAmount;
 
         parent::__construct(
-            "The client (id: {$clientId}) has exceeded the credit limit. "
+            "The client (name: {$clientName}) has exceeded the credit limit. "
             . "Limit: R$ {$creditLimit} | Current exposure:"
             . "R$ {$currentExposure} | New sale: R$ {$newSaleAmount} | Total: R$ {$total}."
         );

--- a/app/Domain/Exceptions/ClosedStockingException.php
+++ b/app/Domain/Exceptions/ClosedStockingException.php
@@ -11,8 +11,8 @@ final class ClosedStockingException extends RuntimeException
     public function __construct(string $stockingId)
     {
         parent::__construct(
-            "A estocagem (id: {$stockingId}) já foi encerrada (despesca total realizada). "
-            . 'Não é possível registrar novas vendas para lotes encerrados.'
+            "The stocking (id: {$stockingId}) has already been closed (total harvest completed). "
+            . 'New registration is not allowed for closed batches.'
         );
     }
 }

--- a/app/Domain/Exceptions/InvalidSaleStatusTransitionException.php
+++ b/app/Domain/Exceptions/InvalidSaleStatusTransitionException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use App\Domain\Enums\SaleStatus;
+use RuntimeException;
+
+final class InvalidSaleStatusTransitionException extends RuntimeException
+{
+    public function __construct(
+        public readonly SaleStatus $from,
+        public readonly SaleStatus $to,
+    ) {
+        parent::__construct(
+            "Cannot transition sale from [{$from->value}] to [{$to->value}]."
+        );
+    }
+}

--- a/app/Domain/Exceptions/SaleFinanciallyLockedException.php
+++ b/app/Domain/Exceptions/SaleFinanciallyLockedException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use RuntimeException;
+
+final class SaleFinanciallyLockedException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'It is not possible to edit the values of a sale with registered receipts.',
+        );
+    }
+}

--- a/app/Domain/Exceptions/StockWithBatchNotFoundException.php
+++ b/app/Domain/Exceptions/StockWithBatchNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use RuntimeException;
+
+final class StockWithBatchNotFoundException extends RuntimeException
+{
+    public function __construct(string $batchId)
+    {
+        parent::__construct("Stock with batch [{$batchId}] not found.");
+    }
+}

--- a/app/Domain/Exceptions/StockingRequiredException.php
+++ b/app/Domain/Exceptions/StockingRequiredException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use RuntimeException;
+
+final class StockingRequiredException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'A stocking_id is required to record a harvest sale. '
+            . 'Sales without a stocking reference are not permitted.'
+        );
+    }
+}

--- a/app/Domain/Models/Batch.php
+++ b/app/Domain/Models/Batch.php
@@ -11,12 +11,14 @@ use Illuminate\Support\Str;
 
 /**
  * @property string              $id
+ * @property string|null         $parent_group_id
  * @property string|null         $name
  * @property string|null         $description
  * @property string              $tank_id
  * @property \Carbon\Carbon|null $entry_date
  * @property int                 $initial_quantity
  * @property float               $unit_cost
+ * @property float               $total_cost
  * @property string              $species
  * @property string              $status
  * @property string|null         $cultivation
@@ -36,12 +38,14 @@ class Batch extends BaseModel
 
     protected $fillable = [
         'id',
+        'parent_group_id',
         'name',
         'description',
         'tank_id',
         'entry_date',
         'initial_quantity',
         'unit_cost',
+        'total_cost',
         'species',
         'status',
         'cultivation',
@@ -51,6 +55,7 @@ class Batch extends BaseModel
         'entry_date'       => 'date:Y-m-d',
         'initial_quantity' => 'integer',
         'unit_cost'        => 'decimal:2',
+        'total_cost'       => 'decimal:2',
     ];
 
     #[\Override]

--- a/app/Domain/Repositories/ClientRepositoryInterface.php
+++ b/app/Domain/Repositories/ClientRepositoryInterface.php
@@ -45,4 +45,14 @@ interface ClientRepositoryInterface
      * Anonimiza os dados sensíveis do cliente (LGPD), preservando id e nome.
      */
     public function anonymize(string $id): bool;
+
+    /**
+     * Find a client by ID or throw ModelNotFoundException.
+     */
+    public function findOrFail(string $id): Client;
+
+    /**
+     * Get the current exposure of the client.
+     */
+    public function getPendingObligations(string $id): float;
 }

--- a/app/Domain/Repositories/FinancialCategoryRepositoryInterface.php
+++ b/app/Domain/Repositories/FinancialCategoryRepositoryInterface.php
@@ -36,10 +36,10 @@ interface FinancialCategoryRepositoryInterface
      * Paginate financial categories filtered by company.
      *
      * @param array{
-     *     company_id: string,
+     *     companyId: string,
      *     type?: string|null,
      *     status?: string|null,
-     *     per_page?: int,
+     *     perPage?: int,
      * } $filters
      */
     public function paginate(array $filters): PaginationInterface;

--- a/app/Domain/Repositories/FinancialTransactionRepositoryInterface.php
+++ b/app/Domain/Repositories/FinancialTransactionRepositoryInterface.php
@@ -6,6 +6,7 @@ namespace App\Domain\Repositories;
 
 use App\Application\DTOs\FinancialTransactionInputDTO;
 use App\Domain\Models\FinancialTransaction;
+use Illuminate\Support\Collection;
 
 interface FinancialTransactionRepositoryInterface
 {
@@ -50,4 +51,11 @@ interface FinancialTransactionRepositoryInterface
      * Find a financial transaction by a specific field.
      */
     public function showFinancialTransaction(string $field, string | int $value): ?FinancialTransaction;
+
+    /**
+     * Find financial transactions by sale ID.
+     *
+     * @return Collection<int, FinancialTransaction>
+     */
+    public function findLockedBySaleId(string $saleId): Collection;
 }

--- a/app/Domain/Repositories/SaleRepositoryInterface.php
+++ b/app/Domain/Repositories/SaleRepositoryInterface.php
@@ -51,4 +51,12 @@ interface SaleRepositoryInterface
      * Pass $excludeSaleId to omit the current sale when re-validating on update.
      */
     public function soldWeightByStocking(string $stockingId, ?string $excludeSaleId = null): float;
+
+    /**
+     * Busca a venda aplicando lockForUpdate (lock pessimista).
+     * Usado pelo UpdateSaleUseCase para evitar edições concorrentes na mesma venda.
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function findOrFailLocked(string $id): Sale;
 }

--- a/app/Domain/Repositories/StockTransactionRepositoryInterface.php
+++ b/app/Domain/Repositories/StockTransactionRepositoryInterface.php
@@ -25,4 +25,21 @@ interface StockTransactionRepositoryInterface
      * @param array<string, mixed> $filters
      */
     public function paginate(array $filters): PaginationInterface;
+
+    /**
+     * Update a stock transaction record.
+     *
+     * @param array<string, mixed> $attributes
+     */
+    public function update(string $id, array $attributes): StockTransaction;
+
+    /**
+     * Delete a stock transaction record.
+     */
+    public function delete(string $id): bool;
+
+    /**
+     * Find a stock transaction by ID.
+     */
+    public function findOrFail(string $id): StockTransaction;
 }

--- a/app/Domain/Repositories/StockingRepositoryInterface.php
+++ b/app/Domain/Repositories/StockingRepositoryInterface.php
@@ -65,4 +65,27 @@ interface StockingRepositoryInterface
      * Find a stocking by company ID.
      */
     public function findByCompanyOrFail(string $stockingId, string $companyId): Stocking;
+
+    /**
+     * Find a stocking by batch ID.
+     */
+    public function findByBatchId(string $batchId): ?Stocking;
+
+    /**
+     * Check if there are any active stockings in a batch.
+     */
+    public function hasActiveStockingsInBatch(string $batchId, string $excludeStockingId = null): bool;
+
+    /**
+     * Get the total accumulated cost of a batch.
+     */
+    public function totalAccumulatedCost(string $stockingId): float;
+
+    /**
+     * Busca o stocking aplicando lockForUpdate (lock pessimista).
+     * Usado pelo UpdateSaleUseCase para evitar edições concorrentes no mesmo stocking.
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function findOrFailLocked(string $id): Stocking;
 }

--- a/app/Domain/ValueObjects/SaleAttributes.php
+++ b/app/Domain/ValueObjects/SaleAttributes.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\ValueObjects;
+
+use App\Domain\Enums\SaleStatus;
+use App\Domain\Models\Sale;
+
+/**
+ * Value Object imutável que carrega apenas os campos presentes no payload do update.
+ *
+ * Responsabilidades:
+ *  - Normalizar tipos (float, bool, enum → valor canônico)
+ *  - Distinguir "campo ausente" de "campo enviado com valor null"
+ *  - Nunca sobrescrever o estado atual da venda com valores não enviados
+ *
+ * Não contém regras de negócio — é apenas um portador de dados validados.
+ */
+final readonly class SaleAttributes
+{
+    private function __construct(
+        /** @var array<string, mixed> */
+        private array $fields,
+    ) {
+    }
+
+    /**
+     * Constrói o Value Object a partir do array validado da Request.
+     * Somente as chaves presentes em $data entram no objeto.
+     *
+     * @param array<string, mixed> $data Array já normalizado (snake_case) e validado.
+     */
+    public static function fromValidatedData(array $data): self
+    {
+        $fields = [];
+
+        if (array_key_exists('total_weight', $data)) {
+            $fields['total_weight'] = (float) $data['total_weight'];
+        }
+
+        if (array_key_exists('price_per_kg', $data)) {
+            $fields['price_per_kg'] = (float) $data['price_per_kg'];
+        }
+
+        if (array_key_exists('sale_date', $data)) {
+            $fields['sale_date'] = $data['sale_date'];
+        }
+
+        if (array_key_exists('status', $data)) {
+            $fields['status'] = SaleStatus::from((string) $data['status'])->value;
+        }
+
+        if (array_key_exists('notes', $data)) {
+            $fields['notes'] = $data['notes'];
+        }
+
+        if (array_key_exists('is_total_harvest', $data)) {
+            $fields['is_total_harvest'] = (bool) $data['is_total_harvest'];
+        }
+
+        return new self($fields);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->fields === [];
+    }
+
+    public function has(string $field): bool
+    {
+        return array_key_exists($field, $this->fields);
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * Retorna o peso efetivo: o novo (se enviado) ou o atual da venda.
+     */
+    public function resolveWeight(Sale $sale): float
+    {
+        return isset($this->fields['total_weight'])
+            ? (float) $this->fields['total_weight']
+            : (float) $sale->total_weight;
+    }
+
+    /**
+     * Retorna o preço efetivo: o novo (se enviado) ou o atual da venda.
+     */
+    public function resolvePrice(Sale $sale): float
+    {
+        return isset($this->fields['price_per_kg'])
+            ? (float) $this->fields['price_per_kg']
+            : (float) $sale->price_per_kg;
+    }
+
+    /**
+     * Retorna se a venda continua/passa a ser despesca total.
+     */
+    public function resolveIsTotalHarvest(Sale $sale): bool
+    {
+        return isset($this->fields['is_total_harvest'])
+            ? (bool) $this->fields['is_total_harvest']
+            : (bool) $sale->is_total_harvest;
+    }
+
+    /**
+     * Retorna uma cópia imutável com a receita total calculada inserida.
+     */
+    public function withRevenue(float $revenue): self
+    {
+        $fields                  = $this->fields;
+        $fields['total_revenue'] = $revenue;
+
+        return new self($fields);
+    }
+}

--- a/app/Infrastructure/Persistence/ClientRepository.php
+++ b/app/Infrastructure/Persistence/ClientRepository.php
@@ -117,4 +117,30 @@ class ClientRepository implements ClientRepositoryInterface
 
         return $client->save();
     }
+
+    /**
+     * Find a client by ID or throw ModelNotFoundException.
+     */
+    public function findOrFail(string $id): Client
+    {
+        return Client::findOrFail($id);
+    }
+
+    /**
+     * Get the current exposure of the client.
+     */
+    public function getPendingObligations(string $id): float
+    {
+        return DB::table('financial_transactions')
+            ->join('sales', 'sales.id', '=', 'financial_transactions.reference_id')
+            ->where('sales.client_id', $id)
+            ->where('financial_transactions.reference_type', 'sale')
+            ->whereIn('financial_transactions.status', [
+                FinancialTransactionStatus::PENDING->value,
+                FinancialTransactionStatus::OVERDUE->value,
+            ])
+            ->whereNull('financial_transactions.deleted_at')
+            ->whereNull('sales.deleted_at')
+            ->sum('financial_transactions.amount');
+    }
 }

--- a/app/Infrastructure/Persistence/FinancialCategoryRepository.php
+++ b/app/Infrastructure/Persistence/FinancialCategoryRepository.php
@@ -61,16 +61,16 @@ final class FinancialCategoryRepository implements FinancialCategoryRepositoryIn
 
     /**
      * @param array{
-     *     company_id: string,
+     *     companyId: string,
      *     type?: string|null,
      *     status?: string|null,
-     *     per_page?: int,
+     *     perPage?: int,
      * } $filters
      */
     public function paginate(array $filters): PaginationInterface
     {
         $paginator = FinancialCategory::with('company:id,name')
-            ->where('company_id', $filters['company_id'])
+            ->where('company_id', $filters['companyId'])
             ->when(
                 ! empty($filters['type']),
                 static fn ($q) => $q->where(
@@ -86,7 +86,7 @@ final class FinancialCategoryRepository implements FinancialCategoryRepositoryIn
                 ),
             )
             ->latest()
-            ->paginate((int) ($filters['per_page'] ?? 25));
+            ->paginate((int) ($filters['perPage'] ?? 25));
 
         return new PaginationPresentr($paginator);
     }

--- a/app/Infrastructure/Persistence/FinancialTransactionRepository.php
+++ b/app/Infrastructure/Persistence/FinancialTransactionRepository.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Infrastructure\Persistence;
 
 use App\Application\DTOs\FinancialTransactionInputDTO;
+use App\Domain\Enums\FinancialTransactionReferenceType;
 use App\Domain\Enums\FinancialTransactionStatus;
 use App\Domain\Enums\FinancialType;
 use App\Domain\Models\FinancialTransaction;
 use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
 use App\Domain\Repositories\PaginationInterface;
+use Illuminate\Support\Collection;
 
 final class FinancialTransactionRepository implements FinancialTransactionRepositoryInterface
 {
@@ -116,5 +118,17 @@ final class FinancialTransactionRepository implements FinancialTransactionReposi
         ])
             ->where($field, $value)
             ->first();
+    }
+
+    /**
+     * @return Collection<int, FinancialTransaction>
+     */
+    public function findLockedBySaleId(string $saleId): Collection
+    {
+        return FinancialTransaction::query()
+            ->where('reference_type', FinancialTransactionReferenceType::SALE->value)
+            ->where('reference_id', $saleId)
+            ->lockForUpdate()
+            ->get();
     }
 }

--- a/app/Infrastructure/Persistence/SaleRepository.php
+++ b/app/Infrastructure/Persistence/SaleRepository.php
@@ -118,4 +118,14 @@ final class SaleRepository implements SaleRepositoryInterface
             )
             ->sum('total_weight');
     }
+
+    public function findOrFailLocked(string $id): Sale
+    {
+        return Sale::with([
+            'company:id,name',
+            'client:id,name',
+            'batch:id,name',
+            'stocking',
+        ])->whereKey($id)->lockForUpdate()->firstOrFail();
+    }
 }

--- a/app/Infrastructure/Persistence/StockTransactionRepository.php
+++ b/app/Infrastructure/Persistence/StockTransactionRepository.php
@@ -19,7 +19,6 @@ final class StockTransactionRepository implements StockTransactionRepositoryInte
             'id'             => (string) Str::uuid(),
             'company_id'     => $dto->companyId,
             'supply_id'      => $dto->supplyId,
-            'supplier_id'    => $dto->supplierId,
             'quantity'       => $dto->quantity,
             'unit_price'     => $dto->unitPrice,
             'total_cost'     => $dto->totalCost,
@@ -61,5 +60,26 @@ final class StockTransactionRepository implements StockTransactionRepositoryInte
             ->paginate((int) ($filters['per_page'] ?? 25));
 
         return new PaginationPresentr($paginator);
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function update(string $id, array $attributes): StockTransaction
+    {
+        $transaction = $this->findOrFail($id);
+        $transaction->update($attributes);
+
+        return $transaction->refresh();
+    }
+
+    public function delete(string $id): bool
+    {
+        return $this->findOrFail($id)->delete();
+    }
+
+    public function findOrFail(string $id): StockTransaction
+    {
+        return StockTransaction::query()->findOrFail($id);
     }
 }

--- a/app/Infrastructure/Persistence/StockingRepository.php
+++ b/app/Infrastructure/Persistence/StockingRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\Persistence;
 
 use App\Application\DTOs\StockingInputDTO;
+use App\Domain\Enums\StockingStatus;
 use App\Domain\Models\Stocking;
 use App\Domain\Repositories\PaginationInterface;
 use App\Domain\Repositories\StockingRepositoryInterface;
@@ -18,27 +19,27 @@ final class StockingRepository implements StockingRepositoryInterface
 
     /**
      * @param array{
-     *     batch_id?: string|null,
-     *     company_id?: string|null,
-     *     date_from?: string|null,
-     *     date_to?: string|null,
+     *     batchId?: string|null,
+     *     companyId?: string|null,
+     *     dateFrom?: string|null,
+     *     dateTo?: string|null,
      *     status?: string|null,
-     *     per_page?: int,
+     *     perPage?: int,
      * } $filters
      */
     public function paginate(array $filters = []): PaginationInterface
     {
         $paginator = Stocking::with(self::DEFAULT_RELATIONS)
             ->when(
-                ! empty($filters['batch_id']),
-                static fn ($q) => $q->where('batch_id', $filters['batch_id']),
+                ! empty($filters['batchId']),
+                static fn ($q) => $q->where('batch_id', $filters['batchId']),
             )
             ->when(
-                ! empty($filters['company_id']),
+                ! empty($filters['companyId']),
                 static function ($q) use ($filters): void {
                     $q->whereHas(
                         'batch.tank',
-                        static fn ($tq) => $tq->where('company_id', $filters['company_id']),
+                        static fn ($tq) => $tq->where('company_id', $filters['companyId']),
                     );
                 },
             )
@@ -47,15 +48,15 @@ final class StockingRepository implements StockingRepositoryInterface
                 static fn ($q) => $q->where('status', $filters['status']),
             )
             ->when(
-                ! empty($filters['date_from']),
-                static fn ($q) => $q->whereDate('stocking_date', '>=', $filters['date_from']),
+                ! empty($filters['dateFrom']),
+                static fn ($q) => $q->whereDate('stocking_date', '>=', $filters['dateFrom']),
             )
             ->when(
-                ! empty($filters['date_to']),
-                static fn ($q) => $q->whereDate('stocking_date', '<=', $filters['date_to']),
+                ! empty($filters['dateTo']),
+                static fn ($q) => $q->whereDate('stocking_date', '<=', $filters['dateTo']),
             )
             ->latest('stocking_date')
-            ->paginate((int) ($filters['per_page'] ?? 25));
+            ->paginate((int) ($filters['perPage'] ?? 25));
 
         return new PaginationPresentr($paginator);
     }
@@ -149,6 +150,41 @@ final class StockingRepository implements StockingRepositoryInterface
                 'batch.tank',
                 static fn ($q) => $q->where('company_id', $companyId),
             )
+            ->firstOrFail();
+    }
+
+    public function findByBatchId(string $batchId): ?Stocking
+    {
+        return Stocking::with(self::DEFAULT_RELATIONS)
+            ->where('batch_id', $batchId)
+            ->where('status', StockingStatus::ACTIVE)
+            ->latest('stocking_date')
+            ->first();
+    }
+
+    public function hasActiveStockingsInBatch(string $batchId, string $excludeStockingId = null): bool
+    {
+        return Stocking::with(self::DEFAULT_RELATIONS)
+            ->where('batch_id', $batchId)
+            ->where('status', StockingStatus::ACTIVE)
+            ->when($excludeStockingId, static function ($query, string $id): void {
+                $query->where('id', '!=', $id);
+            })
+            ->exists();
+    }
+
+    public function totalAccumulatedCost(string $stockingId): float
+    {
+        return (float) Stocking::with(self::DEFAULT_RELATIONS)
+            ->where('id', $stockingId)
+            ->sum('accumulated_fixed_cost');
+    }
+
+    public function findOrFailLocked(string $id): Stocking
+    {
+        return Stocking::with(self::DEFAULT_RELATIONS)
+            ->where('id', $id)
+            ->lockForUpdate()
             ->firstOrFail();
     }
 }

--- a/app/Presentation/Controllers/BatchController.php
+++ b/app/Presentation/Controllers/BatchController.php
@@ -6,10 +6,12 @@ namespace App\Presentation\Controllers;
 
 use App\Application\UseCases\Batch\CreateBatchUseCase;
 use App\Application\UseCases\Batch\DeleteBatchUseCase;
+use App\Application\UseCases\Batch\DistributeBatchUseCase;
 use App\Application\UseCases\Batch\FinishBatchUseCase;
 use App\Application\UseCases\Batch\ListBatchesUseCase;
 use App\Application\UseCases\Batch\ShowBatchUseCase;
 use App\Application\UseCases\Batch\UpdateBatchUseCase;
+use App\Presentation\Requests\Batch\BatchDistributionStoreRequest;
 use App\Presentation\Requests\Batch\BatchFinishRequest;
 use App\Presentation\Requests\Batch\BatchStoreRequest;
 use App\Presentation\Requests\Batch\BatchUpdateRequest;
@@ -33,6 +35,72 @@ use Illuminate\Http\Request;
  *     @OA\Property(property="cultivation", type="string", enum={"growout","nursery"}, nullable=true),
  *     @OA\Property(property="createdAt", type="string", format="date-time", nullable=true),
  *     @OA\Property(property="updatedAt", type="string", format="date-time", nullable=true)
+ * )
+ * @OA\Schema(
+ *     schema="BatchDistributionItem",
+ *     type="object",
+ *     required={"tankId","quantity","averageWeight"},
+ *     @OA\Property(
+ *         property="tankId",
+ *         type="string",
+ *         format="uuid",
+ *         description="Tanque de destino"
+ *     ),
+ *     @OA\Property(
+ *         property="quantity",
+ *         type="integer",
+ *         minimum=1,
+ *         description="Quantidade de alevinos neste tanque"
+ *     ),
+ *     @OA\Property(
+ *         property="averageWeight",
+ *         type="number",
+ *         format="float",
+ *         minimum=0.0001,
+ *         example=0.025,
+ *         description="Peso médio inicial (kg) neste tanque"
+ *     )
+ * )
+ * @OA\Schema(
+ *     schema="BatchDistributionStoreRequest",
+ *     type="object",
+ *     required={"supplierId","totalCost","entryDate","species","cultivation","distribution"},
+ *     @OA\Property(
+ *         property="supplierId",
+ *         type="string",
+ *         format="uuid",
+ *         description="Fornecedor da compra"
+ *     ),
+ *     @OA\Property(
+ *         property="totalCost",
+ *         type="number",
+ *         format="float",
+ *         minimum=0,
+ *         example=2000.00,
+ *         description="Custo total da nota (rateado proporcionalmente por tanque)"
+ *     ),
+ *     @OA\Property(
+ *         property="entryDate",
+ *         type="string",
+ *         format="date",
+ *         example="2026-04-09",
+ *         description="Data de entrada (hoje ou passado)"
+ *     ),
+ *     @OA\Property(property="species", type="string", maxLength=255, example="Tilápia"),
+ *     @OA\Property(property="cultivation", type="string", enum={"growout","nursery"}),
+ *     @OA\Property(
+ *         property="notes",
+ *         type="string",
+ *         nullable=true,
+ *         maxLength=1000,
+ *         description="Observações opcionais"
+ *     ),
+ *     @OA\Property(
+ *         property="distribution",
+ *         type="array",
+ *         description="Lista de tanques e quantidades; cada item gera um lote vinculado ao mesmo parent_group_id",
+ *         @OA\Items(ref="#/components/schemas/BatchDistributionItem")
+ *     )
  * )
  */
 final class BatchController
@@ -284,6 +352,54 @@ final class BatchController
         return ApiResponse::success(
             data:    $report,
             message: 'Batch finished successfully.',
+        );
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/company/batches/distribution",
+     *     summary="Distribuir compra em múltiplos tanques",
+     *     description="Cria um lote por tanque a partir de uma compra; custo proporcional; mesmo parent_group_id.",
+     *     tags={"Batches"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/BatchDistributionStoreRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lotes criados com sucesso",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Batch distributed successfully."),
+     *             @OA\Property(
+     *                 property="response",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="data",
+     *                     type="array",
+     *                     description="Coleção de lotes criados (BatchResource)",
+     *                     @OA\Items(ref="#/components/schemas/Batch")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Erro de validação ou regra de negócio (ex.: tanque com lote ativo, tanque indisponível)"
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
+    public function distribution(
+        BatchDistributionStoreRequest $request,
+        DistributeBatchUseCase $useCase,
+    ): JsonResponse {
+        $batches = $useCase->execute($request->validated());
+
+        return ApiResponse::success(
+            data:    BatchResource::collection($batches),
+            message: 'Batch distributed successfully.',
         );
     }
 }

--- a/app/Presentation/Controllers/FinancialCategoryController.php
+++ b/app/Presentation/Controllers/FinancialCategoryController.php
@@ -49,7 +49,7 @@ final class FinancialCategoryController
      *     tags={"Financial Categories"},
      *     security={{"bearerAuth":{}}},
      *     @OA\Parameter(name="page", in="query", @OA\Schema(type="integer", example=1)),
-     *     @OA\Parameter(name="per_page", in="query", @OA\Schema(type="integer", example=25)),
+     *     @OA\Parameter(name="perPage", in="query", @OA\Schema(type="integer", example=25)),
      *     @OA\Parameter(name="type", in="query", @OA\Schema(type="string", enum={"revenue","expense","investment"})),
      *     @OA\Parameter(name="status", in="query", @OA\Schema(type="string", enum={"active","inactive"})),
      *     @OA\Response(

--- a/app/Presentation/Controllers/SaleController.php
+++ b/app/Presentation/Controllers/SaleController.php
@@ -285,12 +285,19 @@ class SaleController
 
     /**
      * @OA\Delete(
-     *     path="/company/sale/{id}",
-     *     summary="Delete a sale",
+     *     path="/company/sale/{id}/cancel",
+     *     summary="Cancel a sale",
+     *     description="Cancela a venda (rota distinta de excluir permanentemente o registro).",
      *     tags={"Sales"},
      *     security={{"bearerAuth":{}}},
-     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
-     *     @OA\Response(response=200, description="Sale deleted"),
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="Sale ID",
+     *         required=true,
+     *         @OA\Schema(type="string", format="uuid")
+     *     ),
+     *     @OA\Response(response=200, description="Sale cancelled"),
      *     @OA\Response(response=404, description="Sale not found"),
      *     @OA\Response(response=401, description="Unauthorized")
      * )

--- a/app/Presentation/Controllers/SaleController.php
+++ b/app/Presentation/Controllers/SaleController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Presentation\Controllers;
 
+use App\Application\UseCases\Sale\CancelSaleUseCase;
 use App\Application\UseCases\Sale\DeleteSaleUseCase;
 use App\Application\UseCases\Sale\ListSalesUseCase;
 use App\Application\UseCases\Sale\ProcessHarvestSaleUseCase;
@@ -190,11 +191,14 @@ class SaleController
 
         return ApiResponse::created(
             data:    new SaleResource($sale),
-            message: 'Venda registrada com sucesso.',
+            message: 'Sale registered successfully.',
         );
     }
 
     /**
+     * Delegação: {@see UpdateSaleUseCase} → {@see \App\Application\Actions\Sale\UpdateSaleAction}
+     * (transação, locks, trava financeira, biomassa, despesca e sincronização do contas a receber).
+     *
      * @OA\Put(
      *     path="/company/sale/{id}",
      *     summary="Update a sale",
@@ -215,7 +219,22 @@ class SaleController
      *             @OA\Property(property="pricePerKg", type="number", format="float", minimum=0),
      *             @OA\Property(property="saleDate", type="string", format="date"),
      *             @OA\Property(property="status", type="string", enum={"pending","confirmed","cancelled"}),
-     *             @OA\Property(property="notes", type="string", nullable=true)
+     *             @OA\Property(property="notes", type="string", nullable=true),
+     *             @OA\Property(
+     *                 property="batchId",
+     *                 type="string",
+     *                 format="uuid",
+     *                 nullable=true,
+     *                 description="Must match the sale batch; cannot be changed."
+     *             ),
+     *             @OA\Property(
+     *                 property="stockingId",
+     *                 type="string",
+     *                 format="uuid",
+     *                 nullable=true,
+     *                 description="Must match the sale stocking; cannot be changed."
+     *             ),
+     *             @OA\Property(property="isTotalHarvest", type="boolean", nullable=true)
      *         )
      *     ),
      *     @OA\Response(response=200, description="Sale updated"),
@@ -233,7 +252,7 @@ class SaleController
 
         return ApiResponse::success(
             data:    new SaleResource($sale),
-            message: 'Venda atualizada com sucesso.',
+            message: 'Sale updated successfully.',
         );
     }
 
@@ -261,6 +280,27 @@ class SaleController
     ): JsonResponse {
         $useCase->execute($id);
 
-        return ApiResponse::success(message: 'Venda excluída com sucesso.');
+        return ApiResponse::success(message: 'Sale deleted successfully.');
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/company/sale/{id}",
+     *     summary="Delete a sale",
+     *     tags={"Sales"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(response=200, description="Sale deleted"),
+     *     @OA\Response(response=404, description="Sale not found"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
+    public function cancel(
+        string $id,
+        CancelSaleUseCase $useCase,
+    ): JsonResponse {
+        $useCase->execute($id);
+
+        return ApiResponse::success(message: 'Sale cancelled successfully.');
     }
 }

--- a/app/Presentation/Exceptions/Handler.php
+++ b/app/Presentation/Exceptions/Handler.php
@@ -25,8 +25,10 @@ use App\Domain\Exceptions\InsufficientBiomassException;
 use App\Domain\Exceptions\InsufficientStockException;
 use App\Domain\Exceptions\InvalidCredentialsException;
 use App\Domain\Exceptions\InvalidPurchaseStatusTransitionException;
+use App\Domain\Exceptions\InvalidSaleStatusTransitionException;
 use App\Domain\Exceptions\MortalityExceedsSurvivorsException;
 use App\Domain\Exceptions\MortalityNotFoundException;
+use App\Domain\Exceptions\SaleFinanciallyLockedException;
 use App\Domain\Exceptions\StockNotFoundException;
 use App\Domain\Exceptions\TankAlreadyHasActiveBatchException;
 use App\Domain\Exceptions\TransactionAlreadyAllocatedException;
@@ -91,6 +93,8 @@ class Handler extends ExceptionHandler
         // Sale
         InsufficientBiomassException::class,
         ClosedStockingException::class,
+        SaleFinanciallyLockedException::class,
+        InvalidSaleStatusTransitionException::class,
         // CostAllocation
         TransactionAlreadyAllocatedException::class,
         AllocationAmountMismatchException::class,
@@ -307,6 +311,19 @@ class Handler extends ExceptionHandler
         );
         $this->renderable(
             fn (ClosedStockingException $e, Request $r): JsonResponse => $this->handleDomainException(
+                $e,
+                JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+            )
+        );
+        $this->renderable(
+            fn (SaleFinanciallyLockedException $e, Request $r): JsonResponse => $this->handleDomainException(
+                $e,
+                JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+            )
+        );
+
+        $this->renderable(
+            fn (InvalidSaleStatusTransitionException $e, Request $r): JsonResponse => $this->handleDomainException(
                 $e,
                 JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
             )

--- a/app/Presentation/Requests/Batch/BatchDistributionStoreRequest.php
+++ b/app/Presentation/Requests/Batch/BatchDistributionStoreRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Requests\Batch;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class BatchDistributionStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            // Purchase Header
+            'supplierId'  => ['required', 'uuid', 'exists:suppliers,id'],
+            'totalCost'   => ['required', 'numeric', 'min:0'],
+            'entryDate'   => ['required', 'date', 'before_or_equal:today'],
+            'species'     => ['required', 'string', 'max:255'],
+            'cultivation' => ['required', Rule::in(['growout', 'nursery'])],
+            'notes'       => ['nullable', 'string', 'max:1000'],
+            'companyId'   => ['sometimes', 'nullable', 'uuid', 'exists:companies,id'],
+
+            // Distribution Array
+            'distribution'                 => ['required', 'array', 'min:1'],
+            'distribution.*.tankId'        => ['required', 'uuid', 'exists:tanks,id'],
+            'distribution.*.quantity'      => ['required', 'integer', 'min:1'],
+            'distribution.*.averageWeight' => ['required', 'numeric', 'min:0.0001'],
+        ];
+    }
+
+    /**
+     * Custom messages for the nested distribution array.
+     */
+    #[\Override]
+    public function messages(): array
+    {
+        return [
+            'supplierId.exists'                => 'The selected supplier is invalid.',
+            'totalCost.required'               => 'The total cost is required.',
+            'totalCost.numeric'                => 'The total cost must be a number.',
+            'totalCost.min'                    => 'The total cost must be at least 0.',
+            'entryDate.required'               => 'The entry date is required.',
+            'entryDate.date'                   => 'The entry date must be a valid date.',
+            'entryDate.before_or_equal'        => 'The entry date must be today or in the past.',
+            'species.required'                 => 'The species is required.',
+            'species.string'                   => 'The species must be a string.',
+            'species.max'                      => 'The species must be less than 255 characters.',
+            'cultivation.required'             => 'The cultivation is required.',
+            'cultivation.in'                   => 'The cultivation must be either growout or nursery.',
+            'notes.string'                     => 'The notes must be a string.',
+            'notes.max'                        => 'The notes must be less than 1000 characters.',
+            'distribution.required'            => 'At least one tank must be selected for distribution.',
+            'distribution.*.tankId.exists'     => 'One of the selected tanks does not exist.',
+            'distribution.*.quantity.min'      => 'Each tank must receive at least 1 animal.',
+            'distribution.*.averageWeight.min' => 'Average weight must be a positive value.',
+            'companyId.exists'                 => 'The selected company is invalid.',
+        ];
+    }
+}

--- a/app/Presentation/Requests/Sale/SaleStoreRequest.php
+++ b/app/Presentation/Requests/Sale/SaleStoreRequest.php
@@ -8,51 +8,93 @@ use App\Domain\Enums\SaleStatus;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rules\Enum;
 
-class SaleStoreRequest extends FormRequest
+/**
+ * Valida e normaliza o payload de criação de uma venda/despesca.
+ *
+ * Correção em relação à versão anterior:
+ *   - prepareForValidation() usava input('field', input('camelCase')), que injeta
+ *     null silenciosamente quando nenhuma das duas chaves existe, contaminando
+ *     a validação de campos obrigatórios.
+ *   - Agora só normaliza quando a chave camelCase está presente e a snake_case ausente
+ *     (mesmo padrão da SaleUpdateRequest).
+ *
+ * tolerancePercent é aceito no payload mas NÃO é usado pelo ProcessHarvestSaleUseCase
+ * (que usa constante interna de 50%). O campo é mantido no contrato da API por
+ * compatibilidade — remover quando o UseCase passar a consumi-lo.
+ */
+final class SaleStoreRequest extends FormRequest
 {
     public function authorize(): bool
     {
         return true;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $map = [
+            'companyId'           => 'company_id',
+            'clientId'            => 'client_id',
+            'batchId'             => 'batch_id',
+            'stockingId'          => 'stocking_id',
+            'financialCategoryId' => 'financial_category_id',
+            'totalWeight'         => 'total_weight',
+            'pricePerKg'          => 'price_per_kg',
+            'saleDate'            => 'sale_date',
+            'isTotalHarvest'      => 'is_total_harvest',
+            'requiresInvoice'     => 'requires_invoice',
+            'tolerancePercent'    => 'tolerance_percent',
+            'needsInvoice'        => 'needs_invoice',
+        ];
+
+        $normalized = [];
+
+        foreach ($map as $camel => $snake) {
+            if ($this->has($camel) && ! $this->has($snake)) {
+                $normalized[$snake] = $this->input($camel);
+            }
+        }
+
+        if ($normalized !== []) {
+            $this->merge($normalized);
+        }
+    }
+
+    /** @return array<string, mixed[]> */
     public function rules(): array
     {
         return [
             'company_id'            => ['nullable', 'uuid', 'exists:companies,id'],
             'client_id'             => ['required', 'uuid', 'exists:clients,id'],
             'batch_id'              => ['required', 'uuid', 'exists:batches,id'],
-            'stocking_id'           => ['nullable', 'uuid', 'exists:stockings,id'],
+            'stocking_id'           => ['required', 'uuid', 'exists:stockings,id'],
             'financial_category_id' => ['nullable', 'uuid', 'exists:financial_categories,id'],
             'total_weight'          => ['required', 'numeric', 'min:0.001'],
             'price_per_kg'          => ['required', 'numeric', 'min:0'],
             'sale_date'             => ['required', 'date'],
             'status'                => ['nullable', new Enum(SaleStatus::class)],
-            'notes'                 => ['nullable', 'string'],
+            'notes'                 => ['nullable', 'string', 'max:1000'],
             'is_total_harvest'      => ['nullable', 'boolean'],
-            'tolerance_percent'     => ['nullable', 'numeric', 'min:0', 'max:50'],
             'needs_invoice'         => ['nullable', 'boolean'],
+            'tolerance_percent'     => ['nullable', 'numeric', 'min:0', 'max:50'],
         ];
     }
 
-    /**
-     * @return array<string, string>
-     */
+    /** @return array<string, string> */
     #[\Override]
     public function messages(): array
     {
         return [
-            'client_id.required' => 'The customer is required.',
-            'client_id.exists'   => 'The selected customer does not exist.',
+            'client_id.required' => 'The client is required.',
+            'client_id.exists'   => 'The client informed was not found.',
 
             'batch_id.required' => 'The batch is required.',
-            'batch_id.exists'   => 'The selected batch does not exist.',
+            'batch_id.exists'   => 'The batch informed was not found.',
 
-            'stocking_id.exists' => 'The selected stocking does not exist.',
+            'stocking_id.required' => 'The stocking is required.',
+            'stocking_id.exists'   => 'The stocking informed was not found.',
 
-            'financial_category_id.exists' => 'The selected financial category does not exist.',
+            'financial_category_id.exists' => 'The financial category informed was not found.',
 
             'total_weight.required' => 'The total weight is required.',
             'total_weight.numeric'  => 'The total weight must be numeric.',
@@ -69,30 +111,9 @@ class SaleStoreRequest extends FormRequest
 
             'needs_invoice.boolean'     => 'The needs invoice field must be true or false.',
             'is_total_harvest.boolean'  => 'The total harvest field must be true or false.',
-            'tolerance_percent.numeric' => 'The tolerance percent must be numeric.',
-            'tolerance_percent.min'     => 'The tolerance percent must be greater than zero.',
-            'tolerance_percent.max'     => 'The tolerance percent must be less than or equal to 50.',
+            'tolerance_percent.numeric' => 'The tolerance must be numeric.',
+            'tolerance_percent.min'     => 'The tolerance must be greater than zero.',
+            'tolerance_percent.max'     => 'The tolerance must be less than or equal to 50%.',
         ];
-    }
-
-    #[\Override]
-    protected function prepareForValidation(): void
-    {
-        $this->merge([
-            'company_id'            => $this->input('company_id', $this->input('companyId')),
-            'client_id'             => $this->input('client_id', $this->input('clientId')),
-            'batch_id'              => $this->input('batch_id', $this->input('batchId')),
-            'stocking_id'           => $this->input('stocking_id', $this->input('stockingId')),
-            'financial_category_id' => $this->input('financial_category_id', $this->input('financialCategoryId')),
-
-            'total_weight'      => $this->input('total_weight', $this->input('totalWeight')),
-            'price_per_kg'      => $this->input('price_per_kg', $this->input('pricePerKg')),
-            'sale_date'         => $this->input('sale_date', $this->input('saleDate')),
-            'status'            => $this->input('status'),
-            'notes'             => $this->input('notes'),
-            'is_total_harvest'  => $this->input('is_total_harvest', $this->input('isTotalHarvest')),
-            'tolerance_percent' => $this->input('tolerance_percent', $this->input('tolerancePercent')),
-            'needs_invoice'     => $this->input('needs_invoice', $this->input('needsInvoice')),
-        ]);
     }
 }

--- a/app/Presentation/Requests/Sale/SaleUpdateRequest.php
+++ b/app/Presentation/Requests/Sale/SaleUpdateRequest.php
@@ -6,55 +6,71 @@ namespace App\Presentation\Requests\Sale;
 
 use App\Domain\Enums\SaleStatus;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rules\Enum;
+use Illuminate\Validation\Rule;
 
-class SaleUpdateRequest extends FormRequest
+/**
+ * Valida e normaliza o payload de atualização de uma venda.
+ *
+ * Todos os campos são opcionais (PATCH semântico em endpoint PUT):
+ * campos ausentes não sobrescrevem o estado atual da venda.
+ *
+ * A normalização camelCase → snake_case é feita em prepareForValidation()
+ * somente quando a chave camelCase está presente e a snake_case ausente,
+ * evitando injeção silenciosa de null para campos não enviados.
+ */
+final class SaleUpdateRequest extends FormRequest
 {
     public function authorize(): bool
     {
         return true;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $map = [
+            'totalWeight'    => 'total_weight',
+            'pricePerKg'     => 'price_per_kg',
+            'saleDate'       => 'sale_date',
+            'isTotalHarvest' => 'is_total_harvest',
+        ];
+
+        $normalized = [];
+
+        foreach ($map as $camel => $snake) {
+            if ($this->has($camel) && ! $this->has($snake)) {
+                $normalized[$snake] = $this->input($camel);
+            }
+        }
+
+        if ($normalized !== []) {
+            $this->merge($normalized);
+        }
+    }
+
+    /** @return array<string, mixed[]> */
     public function rules(): array
     {
         return [
-            'client_id'    => ['sometimes', 'uuid', 'exists:clients,id'],
-            'total_weight' => ['sometimes', 'numeric', 'min:0.001'],
-            'price_per_kg' => ['sometimes', 'numeric', 'min:0'],
-            'sale_date'    => ['sometimes', 'date'],
-            'status'       => ['sometimes', new Enum(SaleStatus::class)],
-            'notes'        => ['nullable', 'string'],
+            'total_weight'     => ['sometimes', 'numeric', 'min:0.001'],
+            'price_per_kg'     => ['sometimes', 'numeric', 'min:0'],
+            'sale_date'        => ['sometimes', 'date'],
+            'status'           => ['sometimes', Rule::enum(SaleStatus::class)],
+            'notes'            => ['sometimes', 'nullable', 'string', 'max:1000'],
+            'is_total_harvest' => ['sometimes', 'boolean'],
         ];
     }
 
-    /**
-     * @return array<string, string>
-     */
+    /** @return array<string, string> */
     #[\Override]
     public function messages(): array
     {
         return [
-            'client_id.exists'                        => 'The selected customer does not exist.',
-            'total_weight.min'                        => 'The total weight must be greater than zero.',
-            'price_per_kg.min'                        => 'The price per kg must be greater than zero.',
-            'sale_date.date'                          => 'The sale date must be a valid date.',
-            'status.Illuminate\Validation\Rules\Enum' => 'The status must be: pending, confirmed or cancelled.',
+            'total_weight.min' => 'The total weight must be greater than zero.',
+            'price_per_kg.min' => 'The price per kg must be greater than zero.',
+            'sale_date.date'   => 'The sale date must be a valid date.',
+            'status.enum'      => 'The status must be: pending, confirmed or cancelled.',
+            'notes.max'        => 'The notes must not exceed 1000 characters.',
         ];
-    }
-
-    #[\Override]
-    protected function prepareForValidation(): void
-    {
-        $this->merge([
-            'client_id'    => $this->input('client_id', $this->input('clientId')),
-            'total_weight' => $this->input('total_weight', $this->input('totalWeight')),
-            'price_per_kg' => $this->input('price_per_kg', $this->input('pricePerKg')),
-            'sale_date'    => $this->input('sale_date', $this->input('saleDate')),
-            'status'       => $this->input('status'),
-            'notes'        => $this->input('notes'),
-        ]);
     }
 }

--- a/app/Presentation/Resources/Sale/SaleResource.php
+++ b/app/Presentation/Resources/Sale/SaleResource.php
@@ -5,37 +5,21 @@ declare(strict_types=1);
 namespace App\Presentation\Resources\Sale;
 
 use App\Domain\Enums\SaleStatus;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
- * @property-read string                          $id
- * @property-read string                          $company_id
- * @property-read string                          $client_id
- * @property-read string                          $batch_id
- * @property-read string|null                     $stocking_id
- * @property-read string|null                     $financial_category_id
- * @property-read float                           $total_weight
- * @property-read float                           $price_per_kg
- * @property-read float                           $total_revenue
- * @property-read \Illuminate\Support\Carbon      $sale_date
- * @property-read SaleStatus                      $status
- * @property-read string|null                     $notes
- * @property-read \Illuminate\Support\Carbon|null $created_at
- * @property-read \Illuminate\Support\Carbon|null $updated_at
- * @property-read \App\Domain\Models\Company|null $company
- * @property-read \App\Domain\Models\Client|null  $client
- * @property-read \App\Domain\Models\Batch|null   $batch
- * @property-read \App\Domain\Models\Stocking|null $stocking
+ * @mixin \App\Domain\Models\Sale
  */
-class SaleResource extends JsonResource
+final class SaleResource extends JsonResource
 {
     /**
-     * @param \Illuminate\Http\Request $request
      * @return array<string, mixed>
      */
     #[\Override]
-    public function toArray($request): array
+    public function toArray(Request $request): array
     {
+        /** @var SaleStatus $status */
         $status = $this->status;
 
         return [
@@ -49,24 +33,27 @@ class SaleResource extends JsonResource
             'notes'        => $this->notes,
             'batchId'      => $this->batch_id,
             'stockingId'   => $this->stocking_id,
-            'company'      => $this->whenLoaded('company', fn (): array => [
+
+            'company' => $this->whenLoaded('company', fn (): array => [
                 'name' => $this->company->name,
             ]),
+
             'client' => $this->whenLoaded('client', fn (): array => [
                 'id'   => $this->client->id,
                 'name' => $this->client->name,
             ]),
+
             'batch' => $this->whenLoaded('batch', fn (): array => [
                 'id'   => $this->batch->id,
                 'name' => $this->batch->name,
             ]),
-            'stocking' => $this->whenLoaded('stocking', fn (): ?array => $this->stocking
-                ? [
-                    'id'            => $this->stocking->id,
-                    'quantity'      => $this->stocking->quantity,
-                    'averageWeight' => $this->stocking->average_weight,
-                ]
-                : null),
+
+            'stocking' => $this->whenLoaded('stocking', fn (): ?array => $this->stocking ? [
+                'id'            => $this->stocking->id,
+                'quantity'      => $this->stocking->quantity,
+                'averageWeight' => $this->stocking->average_weight,
+            ] : null),
+
             'createdAt' => $this->created_at?->toDateTimeString(),
             'updatedAt' => $this->updated_at?->toDateTimeString(),
         ];

--- a/database/migrations/2026_04_08_120000_add_parent_group_and_cost_fields_to_batches_table.php
+++ b/database/migrations/2026_04_08_120000_add_parent_group_and_cost_fields_to_batches_table.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('batches')) {
+            return;
+        }
+
+        Schema::table('batches', function (Blueprint $table): void {
+            if (! Schema::hasColumn('batches', 'parent_group_id')) {
+                $table->uuid('parent_group_id')->nullable()->after('id');
+                $table->index('parent_group_id', 'batches_parent_group_id_index');
+            }
+
+            if (! Schema::hasColumn('batches', 'unit_cost')) {
+                $table->decimal('unit_cost', 15, 2)->default(0.00)->after('initial_quantity');
+            }
+
+            if (! Schema::hasColumn('batches', 'total_cost')) {
+                $table->decimal('total_cost', 15, 2)->default(0.00)->after('unit_cost');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('batches')) {
+            return;
+        }
+
+        Schema::table('batches', function (Blueprint $table): void {
+            if (Schema::hasColumn('batches', 'total_cost')) {
+                $table->dropColumn('total_cost');
+            }
+
+            if (Schema::hasColumn('batches', 'unit_cost')) {
+                $table->dropColumn('unit_cost');
+            }
+
+            if (Schema::hasColumn('batches', 'parent_group_id')) {
+                $table->dropIndex('batches_parent_group_id_index');
+                $table->dropColumn('parent_group_id');
+            }
+        });
+    }
+};

--- a/routes/app/company/batch.php
+++ b/routes/app/company/batch.php
@@ -13,4 +13,5 @@ Route::middleware(['permission:create-batch|view-batch|update-batch|delete-batch
         Route::put('batch/{id}', [BatchController::class, 'update']);
         Route::delete('batch/{id}', [BatchController::class, 'destroy']);
         Route::post('batch/{id}/finish', [BatchController::class, 'finish']);
+        Route::post('batches/distribution', [BatchController::class, 'distribution']);
     });

--- a/routes/app/company/sale.php
+++ b/routes/app/company/sale.php
@@ -19,3 +19,6 @@ Route::middleware(['permission:update-sale'])
 
 Route::middleware(['permission:delete-sale'])
     ->delete('sale/{id}', [SaleController::class, 'destroy']);
+
+Route::middleware(['permission:cancel-sale'])
+    ->delete('sale/{id}/cancel', [SaleController::class, 'cancel']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -478,6 +478,71 @@
                 ]
             }
         },
+        "/company/batches/distribution": {
+            "post": {
+                "tags": [
+                    "Batches"
+                ],
+                "summary": "Distribuir compra em múltiplos tanques",
+                "description": "Cria um lote por tanque a partir de uma compra; custo proporcional; mesmo parent_group_id.",
+                "operationId": "e3c5d329619ddbb4844d4bb0ea1dbcf4",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchDistributionStoreRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Lotes criados com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Batch distributed successfully."
+                                        },
+                                        "response": {
+                                            "properties": {
+                                                "data": {
+                                                    "description": "Coleção de lotes criados (BatchResource)",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/Batch"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erro de validação ou regra de negócio (ex.: tanque com lote ativo, tanque indisponível)"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "/company/biometries": {
             "get": {
                 "tags": [
@@ -3004,7 +3069,7 @@
                         }
                     },
                     {
-                        "name": "per_page",
+                        "name": "perPage",
                         "in": "query",
                         "schema": {
                             "type": "integer",
@@ -5789,6 +5854,7 @@
                     "Sales"
                 ],
                 "summary": "Update a sale",
+                "description": "Delegação: {@see UpdateSaleUseCase} → {@see \\App\\Application\\Actions\\Sale\\UpdateSaleAction}\n(transação, locks, trava financeira, biomassa, despesca e sincronização do contas a receber).",
                 "operationId": "9f828e63cc636983eed7faec42f4f1e3",
                 "parameters": [
                     {
@@ -5836,6 +5902,22 @@
                                     },
                                     "notes": {
                                         "type": "string",
+                                        "nullable": true
+                                    },
+                                    "batchId": {
+                                        "description": "Must match the sale batch; cannot be changed.",
+                                        "type": "string",
+                                        "format": "uuid",
+                                        "nullable": true
+                                    },
+                                    "stockingId": {
+                                        "description": "Must match the sale stocking; cannot be changed.",
+                                        "type": "string",
+                                        "format": "uuid",
+                                        "nullable": true
+                                    },
+                                    "isTotalHarvest": {
+                                        "type": "boolean",
                                         "nullable": true
                                     }
                                 },
@@ -6003,6 +6085,44 @@
                     },
                     "404": {
                         "description": "Related entities not found"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/company/sale/{id}/cancel": {
+            "delete": {
+                "tags": [
+                    "Sales"
+                ],
+                "summary": "Cancel a sale",
+                "description": "Cancela a venda (rota distinta de excluir permanentemente o registro).",
+                "operationId": "51040e4db576a2094dec4d25a3fd5cab",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Sale ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Sale cancelled"
+                    },
+                    "404": {
+                        "description": "Sale not found"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
                     }
                 },
                 "security": [
@@ -10976,6 +11096,89 @@
                 },
                 "type": "object"
             },
+            "BatchDistributionItem": {
+                "required": [
+                    "tankId",
+                    "quantity",
+                    "averageWeight"
+                ],
+                "properties": {
+                    "tankId": {
+                        "description": "Tanque de destino",
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "quantity": {
+                        "description": "Quantidade de alevinos neste tanque",
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "averageWeight": {
+                        "description": "Peso médio inicial (kg) neste tanque",
+                        "type": "number",
+                        "format": "float",
+                        "minimum": 0.0001,
+                        "example": 0.025
+                    }
+                },
+                "type": "object"
+            },
+            "BatchDistributionStoreRequest": {
+                "required": [
+                    "supplierId",
+                    "totalCost",
+                    "entryDate",
+                    "species",
+                    "cultivation",
+                    "distribution"
+                ],
+                "properties": {
+                    "supplierId": {
+                        "description": "Fornecedor da compra",
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "totalCost": {
+                        "description": "Custo total da nota (rateado proporcionalmente por tanque)",
+                        "type": "number",
+                        "format": "float",
+                        "minimum": 0,
+                        "example": 2000
+                    },
+                    "entryDate": {
+                        "description": "Data de entrada (hoje ou passado)",
+                        "type": "string",
+                        "format": "date",
+                        "example": "2026-04-09"
+                    },
+                    "species": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "example": "Tilápia"
+                    },
+                    "cultivation": {
+                        "type": "string",
+                        "enum": [
+                            "growout",
+                            "nursery"
+                        ]
+                    },
+                    "notes": {
+                        "description": "Observações opcionais",
+                        "type": "string",
+                        "maxLength": 1000,
+                        "nullable": true
+                    },
+                    "distribution": {
+                        "description": "Lista de tanques e quantidades; cada item gera um lote vinculado ao mesmo parent_group_id",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/BatchDistributionItem"
+                        }
+                    }
+                },
+                "type": "object"
+            },
             "Company": {
                 "properties": {
                     "id": {
@@ -12585,11 +12788,11 @@
         },
         {
             "name": "Water Qualities",
-            "description": "Medições de qualidade da água por tanque"
+            "description": "Water quality measurements by tank"
         },
         {
             "name": "Cost Allocation",
-            "description": "Rateios de custo"
+            "description": "Cost Allocation"
         },
         {
             "name": "Dashboard",
@@ -12597,11 +12800,11 @@
         },
         {
             "name": "Harvest",
-            "description": "Colheitas"
+            "description": "Harvest"
         },
         {
             "name": "Sensor readings",
-            "description": "Leituras de sensores"
+            "description": "Sensor readings"
         }
     ]
 }


### PR DESCRIPTION
Implementa o fluxo completo de Sales Order e Sales Quotation, incluindo
entidades, DTOs, use cases, repositórios, controllers, requests e resources.

- Cria conversão de cotação para pedido e regras de status/cancelamento.
- Adiciona migrations, permissões e rotas de sales order.
- Integra ajustes no fluxo financeiro (receivable/payable) e cancelamento de venda.
- Atualiza tratamento de exceções e documentação OpenAPI.