### PR TITLE
Feat/sale order

### DIFF
--- a/app/Application/Actions/FinancialTransaction/GenerateFinancialTransactionAction.php
+++ b/app/Application/Actions/FinancialTransaction/GenerateFinancialTransactionAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\FinancialTransaction;
+
+use App\Application\DTOs\FinancialTransactionInputDTO;
+use App\Application\Services\FinancialTransactionService;
+use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
+
+/**
+ * Gera uma transação financeira validando categoria/tipo e regras de pagamento.
+ */
+final readonly class GenerateFinancialTransactionAction
+{
+    public function __construct(
+        private FinancialTransactionRepositoryInterface $transactionRepository,
+        private FinancialTransactionService $transactionService,
+    ) {
+    }
+
+    public function execute(FinancialTransactionInputDTO $dto): void
+    {
+        if ($dto->financialCategoryId === '') {
+            return;
+        }
+
+        $this->transactionService->validateCategoryType(
+            categoryId: $dto->financialCategoryId,
+            transactionType: $dto->type,
+        );
+
+        $this->transactionRepository->create(
+            $this->transactionService->applyPaymentDateToDTO($dto),
+        );
+    }
+}

--- a/app/Application/Actions/FinancialTransaction/GeneratePayableAction.php
+++ b/app/Application/Actions/FinancialTransaction/GeneratePayableAction.php
@@ -6,11 +6,9 @@ namespace App\Application\Actions\FinancialTransaction;
 
 use App\Application\DTOs\ExpenseInputDTO;
 use App\Application\DTOs\FinancialTransactionInputDTO;
-use App\Application\Services\FinancialTransactionService;
 use App\Domain\Enums\FinancialTransactionReferenceType;
 use App\Domain\Enums\FinancialTransactionStatus;
 use App\Domain\Enums\FinancialType;
-use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
 
 /**
  * Gera automaticamente o "Contas a Pagar" (PENDING) vinculado à despesa.
@@ -21,22 +19,12 @@ use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
 final readonly class GeneratePayableAction
 {
     public function __construct(
-        private FinancialTransactionRepositoryInterface $transactionRepository,
-        private FinancialTransactionService $transactionService,
+        private GenerateFinancialTransactionAction $generateFinancialTransaction,
     ) {
     }
 
     public function execute(ExpenseInputDTO $dto, string $referenceId): void
     {
-        if ($dto->financialCategoryId === null) {
-            return;
-        }
-
-        $this->transactionService->validateCategoryType(
-            categoryId:      $dto->financialCategoryId,
-            transactionType: FinancialType::EXPENSE,
-        );
-
         $payableDTO = new FinancialTransactionInputDTO(
             companyId:           $dto->companyId,
             financialCategoryId: $dto->financialCategoryId,
@@ -51,8 +39,6 @@ final readonly class GeneratePayableAction
             referenceId:         $referenceId,
         );
 
-        $this->transactionRepository->create(
-            $this->transactionService->applyPaymentDateToDTO($payableDTO),
-        );
+        $this->generateFinancialTransaction->execute($payableDTO);
     }
 }

--- a/app/Application/Actions/FinancialTransaction/GenerateReceivableAction.php
+++ b/app/Application/Actions/FinancialTransaction/GenerateReceivableAction.php
@@ -2,16 +2,13 @@
 
 declare(strict_types=1);
 
-namespace App\Application\Actions\Sale;
+namespace App\Application\Actions\FinancialTransaction;
 
 use App\Application\DTOs\FinancialTransactionInputDTO;
 use App\Application\DTOs\SaleInputDTO;
-use App\Application\Services\FinancialTransactionService;
 use App\Domain\Enums\FinancialTransactionReferenceType;
 use App\Domain\Enums\FinancialTransactionStatus;
 use App\Domain\Enums\FinancialType;
-use App\Domain\Models\Sale;
-use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
 
 /**
  * Gera automaticamente o "Contas a Receber" (PENDING) vinculado à venda.
@@ -22,22 +19,12 @@ use App\Domain\Repositories\FinancialTransactionRepositoryInterface;
 final readonly class GenerateReceivableAction
 {
     public function __construct(
-        private FinancialTransactionRepositoryInterface $transactionRepository,
-        private FinancialTransactionService $transactionService,
+        private GenerateFinancialTransactionAction $generateFinancialTransaction,
     ) {
     }
 
-    public function execute(SaleInputDTO $dto, Sale $sale): void
+    public function execute(SaleInputDTO $dto, string $referenceId): void
     {
-        if ($dto->financialCategoryId === null) {
-            return;
-        }
-
-        $this->transactionService->validateCategoryType(
-            categoryId:      $dto->financialCategoryId,
-            transactionType: FinancialType::REVENUE,
-        );
-
         $receivableDTO = new FinancialTransactionInputDTO(
             companyId:           $dto->companyId,
             financialCategoryId: $dto->financialCategoryId,
@@ -46,13 +33,12 @@ final readonly class GenerateReceivableAction
             dueDate:             $dto->saleDate,
             status:              FinancialTransactionStatus::PENDING,
             paymentDate:         null,
-            description:         "Contas a Receber — Venda #{$sale->id}",
+            description:         "Contas a Receber — Venda #{$referenceId}",
+            notes:               $dto->notes,
             referenceType:       FinancialTransactionReferenceType::SALE,
-            referenceId:         (string) $sale->id,
+            referenceId:         $referenceId,
         );
 
-        $this->transactionRepository->create(
-            $this->transactionService->applyPaymentDateToDTO($receivableDTO),
-        );
+        $this->generateFinancialTransaction->execute($receivableDTO);
     }
 }

--- a/app/Application/Actions/Sale/CancelSaleAction.php
+++ b/app/Application/Actions/Sale/CancelSaleAction.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Actions\Sale;
+
+use App\Domain\Enums\SaleStatus;
+use App\Domain\Models\Sale;
+use App\Domain\Repositories\SaleRepositoryInterface;
+use App\Domain\Repositories\StockingRepositoryInterface;
+
+final readonly class CancelSaleAction
+{
+    public function __construct(
+        private SaleRepositoryInterface $saleRepository,
+        private StockingRepositoryInterface $stockingRepository,
+        private CancelSaleReceivablesAction $cancelReceivables,
+        private RevertBiomassOutflowAction $revertBiomassOutflow,
+        private ReopenStockingAndBatchAction $reopenStockingAndBatch,
+    ) {
+    }
+
+    /**
+     * Desfaz os efeitos colaterais de uma venda e a marca como cancelada.
+     *
+     * Deve ser chamada dentro de uma DB::transaction existente
+     * — não abre transação própria para permitir execução em lote
+     * (ex: cancelamento de todas as vendas de um pedido).
+     *
+     * Passo 1 — Cancela recebíveis (bloqueia se pago → SaleFinanciallyLockedException)
+     * Passo 2 — Estorna biomassa (contra-lançamento IN + soft-delete no OUT)
+     * Passo 3 — Reabre stocking/batch se era despesca total
+     * Passo 4 — Marca a venda como CANCELLED
+     *
+     * @throws \App\Domain\Exceptions\SaleFinanciallyLockedException
+     */
+    public function execute(Sale $sale): void
+    {
+        // Passo 1: trava financeira — se pago, para aqui antes de qualquer outra escrita
+        $this->cancelReceivables->execute((string) $sale->id);
+
+        // Passo 2: estorno de biomassa
+        $this->revertBiomassOutflow->execute($sale);
+
+        // Passo 3: reabre ciclo de vida apenas se era despesca total e stocking ainda fechado
+        if ($sale->stocking_id !== null && (bool) $sale->is_total_harvest) {
+            $stocking = $this->stockingRepository->findOrFailLocked((string) $sale->stocking_id);
+
+            if ($stocking->isClosed()) {
+                $this->reopenStockingAndBatch->execute($stocking, (string) $sale->batch_id);
+            }
+        }
+
+        // Passo 4: cancela a venda
+        $this->saleRepository->update(
+            (string) $sale->id,
+            [
+            'status' => SaleStatus::CANCELLED->value,
+            ]
+        );
+    }
+}

--- a/app/Application/DTOs/ConvertQuotationDTO.php
+++ b/app/Application/DTOs/ConvertQuotationDTO.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\DTOs;
+
+final readonly class ConvertQuotationDTO
+{
+    public function __construct(
+        public string $expectedDeliveryDate,
+        public string $financialCategoryId,
+        public string $expectedPaymentDate,
+        public bool $needsInvoice,
+        public ?string $notes = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            expectedDeliveryDate: (string) ($data['expected_delivery_date'] ?? $data['expectedDeliveryDate'] ?? ''),
+            financialCategoryId:  (string) ($data['financial_category_id'] ?? $data['financialCategoryId'] ?? ''),
+            expectedPaymentDate:  (string) ($data['expected_payment_date'] ?? $data['expectedPaymentDate'] ?? ''),
+            needsInvoice:         (bool)   ($data['needs_invoice'] ?? $data['needsInvoice'] ?? false),
+            notes:                isset($data['notes']) && is_string($data['notes']) ? $data['notes'] : null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPersistenceOverrides(): array
+    {
+        $overrides = [
+            'expected_delivery_date' => $this->expectedDeliveryDate,
+        ];
+
+        if ($this->notes !== null) {
+            $overrides['notes'] = $this->notes;
+        }
+
+        return $overrides;
+    }
+}

--- a/app/Application/DTOs/SalesOrderDTO.php
+++ b/app/Application/DTOs/SalesOrderDTO.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\DTOs;
+
+final readonly class SalesOrderDTO
+{
+    /**
+     * @param SalesOrderItemDTO[] $items
+     */
+    public function __construct(
+        public string $companyId,
+        public string $clientId,
+        public string $issueDate,
+        public string $expectedDeliveryDate,
+        public string $type,
+        public string $financialCategoryId,
+        public string $expectedPaymentDate,
+        public bool $needsInvoice,
+        public array $items,
+        public ?string $notes = null,
+    ) {
+    }
+
+    /**
+     * Calcula o total do pedido somando os subtotais dos itens.
+     * Lógica financeira no DTO — não no repositório.
+     */
+    public function totalAmount(): float
+    {
+        return round(
+            array_sum(
+                array_map(static fn (SalesOrderItemDTO $i): float => $i->subtotal(), $this->items)
+            ),
+            2
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $items = array_map(
+            SalesOrderItemDTO::fromArray(...),
+            (array) ($data['items'] ?? []),
+        );
+
+        return new self(
+            companyId:      (string) ($data['company_id'] ?? $data['companyId'] ?? ''),
+            clientId:       (string) ($data['client_id'] ?? $data['clientId'] ?? ''),
+            issueDate:      (string) ($data['issue_date'] ?? $data['issueDate'] ?? ''),
+            expectedDeliveryDate: (string) ($data['expected_delivery_date'] ?? $data['expectedDeliveryDate'] ?? ''),
+            type:             (string) ($data['type'] ?? 'order'),
+            financialCategoryId: isset($data['financial_category_id'])
+                ? (string) $data['financial_category_id']
+                : (isset($data['financialCategoryId']) ? (string) $data['financialCategoryId'] : null),
+            expectedPaymentDate: isset($data['expected_payment_date'])
+                ? (string) $data['expected_payment_date']
+                : (isset($data['expectedPaymentDate']) ? (string) $data['expectedPaymentDate'] : null),
+            needsInvoice:        (bool) ($data['needs_invoice'] ?? $data['needsInvoice'] ?? false),
+            items:          $items,
+            notes:          isset($data['notes']) && is_string($data['notes']) ? $data['notes'] : null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPersistence(): array
+    {
+        return [
+            'company_id'             => $this->companyId,
+            'client_id'              => $this->clientId,
+            'issue_date'             => $this->issueDate,
+            'expected_delivery_date' => $this->expectedDeliveryDate,
+            'type'                   => $this->type,
+            'notes'                  => $this->notes,
+            'total_amount'           => $this->totalAmount(),
+        ];
+    }
+}

--- a/app/Application/DTOs/SalesOrderItemDTO.php
+++ b/app/Application/DTOs/SalesOrderItemDTO.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\DTOs;
+
+final readonly class SalesOrderItemDTO
+{
+    public function __construct(
+        public string $stockingId,
+        public float $quantity,
+        public float $unitPrice,
+        public string $measureUnit,
+        public ?string $id = null,
+    ) {
+    }
+
+    public function subtotal(): float
+    {
+        return round($this->quantity * $this->unitPrice, 2);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            stockingId:     (string) ($row['stocking_id'] ?? $row['stockingId'] ?? ''),
+            quantity:    (float)  ($row['quantity'] ?? 0),
+            unitPrice:   (float)  ($row['unit_price'] ?? $row['unitPrice'] ?? 0),
+            measureUnit: (string) ($row['measure_unit'] ?? $row['measureUnit'] ?? 'kg'),
+            id:          (string) ($row['id'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPersistence(string $salesOrderId): array
+    {
+        return [
+            'sales_order_id' => $salesOrderId,
+            'stocking_id'    => $this->stockingId,
+            'quantity'       => $this->quantity,
+            'unit_price'     => $this->unitPrice,
+            'subtotal'       => $this->subtotal(),
+            'measure_unit'   => $this->measureUnit,
+        ];
+    }
+}

--- a/app/Application/DTOs/SalesOrderUpdateDTO.php
+++ b/app/Application/DTOs/SalesOrderUpdateDTO.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\DTOs;
+
+final readonly class SalesOrderUpdateDTO
+{
+    /**
+     * @param SalesOrderItemDTO[]|null $items         null = nao alterar itens
+     * @param bool                     $notesProvided Verdadeiro se 'notes' foi enviado (distingue ausente de null)
+     */
+    public function __construct(
+        public ?string $clientId,
+        public ?string $issueDate,
+        public ?string $expirationDate,
+        public ?string $notes,
+        public ?array $items,
+        private bool $notesProvided = false,
+    ) {
+    }
+
+    /**
+     * Recalcula total_amount apenas quando os itens foram enviados.
+     * Retorna null quando itens nao foram alterados.
+     */
+    public function totalAmount(): ?float
+    {
+        if ($this->items === null) {
+            return null;
+        }
+
+        return round(
+            array_sum(
+                array_map(static fn (SalesOrderItemDTO $i): float => $i->subtotal(), $this->items)
+            ),
+            2
+        );
+    }
+
+    /**
+     * Retorna os atributos escalares presentes no patch.
+     * Nao sobrescreve campos ausentes.
+     *
+     * @return array<string, mixed>
+     */
+    public function toScalarAttributes(): array
+    {
+        $attributes = [];
+
+        if ($this->clientId !== null) {
+            $attributes['client_id'] = $this->clientId;
+        }
+
+        if ($this->issueDate !== null) {
+            $attributes['issue_date'] = $this->issueDate;
+        }
+
+        if ($this->expirationDate !== null) {
+            $attributes['expiration_date'] = $this->expirationDate;
+        }
+
+        if ($this->notesProvided) {
+            $attributes['notes'] = $this->notes;
+        }
+
+        $total = $this->totalAmount();
+
+        if ($total !== null) {
+            $attributes['total_amount'] = $total;
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $items = null;
+
+        if (array_key_exists('items', $data) && is_array($data['items'])) {
+            $items = array_map(
+                SalesOrderItemDTO::fromArray(...),
+                $data['items'],
+            );
+        }
+
+        return new self(
+            clientId:       isset($data['client_id']) ? (string) $data['client_id'] : null,
+            issueDate:      isset($data['issue_date']) ? (string) $data['issue_date'] : null,
+            expirationDate: isset($data['expiration_date']) ? (string) $data['expiration_date'] : null,
+            notes:          array_key_exists('notes', $data)
+                                ? ($data['notes'] !== null ? (string) $data['notes'] : null)
+                                : null,
+            items:          $items,
+            notesProvided:  array_key_exists('notes', $data),
+        );
+    }
+}

--- a/app/Application/DTOs/SalesQuotationDTO.php
+++ b/app/Application/DTOs/SalesQuotationDTO.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\DTOs;
+
+final readonly class SalesQuotationDTO
+{
+    /**
+     * @param SalesOrderItemDTO[] $items
+     */
+    public function __construct(
+        public string $companyId,
+        public string $clientId,
+        public string $issueDate,
+        public string $expirationDate,
+        public array $items,
+        public ?string $notes = null,
+    ) {
+    }
+
+    /**
+     * Calcula o total do pedido somando os subtotais dos itens.
+     * Lógica financeira no DTO — não no repositório.
+     */
+    public function totalAmount(): float
+    {
+        return round(
+            array_sum(
+                array_map(static fn (SalesOrderItemDTO $i): float => $i->subtotal(), $this->items)
+            ),
+            2
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $items = array_map(
+            SalesOrderItemDTO::fromArray(...),
+            (array) ($data['items'] ?? []),
+        );
+
+        return new self(
+            companyId:      (string) ($data['company_id'] ?? $data['companyId'] ?? ''),
+            clientId:       (string) ($data['client_id'] ?? $data['clientId'] ?? ''),
+            issueDate:      (string) ($data['issue_date'] ?? $data['issueDate'] ?? ''),
+            expirationDate: (string) ($data['expiration_date'] ?? $data['expirationDate'] ?? ''),
+            items:          $items,
+            notes:          isset($data['notes']) && is_string($data['notes']) ? $data['notes'] : null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPersistence(): array
+    {
+        return [
+            'company_id'      => $this->companyId,
+            'client_id'       => $this->clientId,
+            'issue_date'      => $this->issueDate,
+            'expiration_date' => $this->expirationDate,
+            'total_amount'    => $this->totalAmount(),
+            'notes'           => $this->notes,
+        ];
+    }
+}

--- a/app/Application/Listeners/GenerateStockingHistory.php
+++ b/app/Application/Listeners/GenerateStockingHistory.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Str;
  *
  * Mudança em relação à versão anterior:
  *  - findActiveStockingByBatch() usava Stocking::query() diretamente.
- *    Agora usa StockingRepositoryInterface::findByBatchId() — mantém
+ *    Agora usa StockingRepositoryInterface::findByBatchOrFail() — mantém
  *    a camada de infraestrutura encapsulada e facilita testes.
  *
  * Registrado para: FeedingCreated | MortalityRecorded | SaleProcessed
@@ -32,11 +32,7 @@ final readonly class GenerateStockingHistory
 
     public function handleFeedingCreated(FeedingCreated $event): void
     {
-        $stocking = $this->stockingRepository->findByBatchId($event->feeding->batch_id);
-
-        if (! $stocking instanceof Stocking) {
-            return;
-        }
+        $stocking = $this->stockingRepository->findByBatchOrFail($event->feeding->batch_id);
 
         StockingHistory::create([
             'id'          => (string) Str::uuid(),
@@ -54,11 +50,7 @@ final readonly class GenerateStockingHistory
 
     public function handleMortalityRecorded(MortalityRecorded $event): void
     {
-        $stocking = $this->stockingRepository->findByBatchId($event->mortality->batch_id);
-
-        if (! $stocking instanceof Stocking) {
-            return;
-        }
+        $stocking = $this->stockingRepository->findByBatchOrFail($event->mortality->batch_id);
 
         StockingHistory::create([
             'id'          => (string) Str::uuid(),

--- a/app/Application/UseCases/Batch/DistributeBatchUseCase.php
+++ b/app/Application/UseCases/Batch/DistributeBatchUseCase.php
@@ -37,6 +37,6 @@ final readonly class DistributeBatchUseCase
 
         $this->validateTanks->execute($input);
 
-        return DB::transaction(fn (): \Illuminate\Support\Collection => $this->createBatches->execute($input));
+        return DB::transaction(fn (): Collection => $this->createBatches->execute($input));
     }
 }

--- a/app/Application/UseCases/Sale/CancelSaleUseCase.php
+++ b/app/Application/UseCases/Sale/CancelSaleUseCase.php
@@ -4,85 +4,33 @@ declare(strict_types=1);
 
 namespace App\Application\UseCases\Sale;
 
-use App\Application\Actions\Sale\CancelSaleReceivablesAction;
-use App\Application\Actions\Sale\ReopenStockingAndBatchAction;
-use App\Application\Actions\Sale\RevertBiomassOutflowAction;
-use App\Domain\Enums\SaleStatus;
-use App\Domain\Models\Sale;
-use App\Domain\Models\Stocking;
+use App\Application\Actions\Sale\CancelSaleAction;
 use App\Domain\Repositories\SaleRepositoryInterface;
-use App\Domain\Repositories\StockingRepositoryInterface;
 use Illuminate\Support\Facades\DB;
 
 final readonly class CancelSaleUseCase
 {
     public function __construct(
         private SaleRepositoryInterface $saleRepository,
-        private StockingRepositoryInterface $stockingRepository,
-        private CancelSaleReceivablesAction $cancelReceivables,
-        private RevertBiomassOutflowAction $revertBiomassOutflow,
-        private ReopenStockingAndBatchAction $reopenStockingAndBatch,
+        private CancelSaleAction $cancelSale,
     ) {
     }
 
     /**
-     * Desfaz uma venda de forma atômica revertendo todos os efeitos colaterais:
+     * Cancela uma única venda de forma atômica.
+     * Toda a lógica está em CancelSaleAction — reutilizada pelo CancelSalesOrderUseCase.
      *
-     *   Passo 1 — Trava financeira
-     *             Cancela os Contas a Receber (pending/overdue → cancelled).
-     *             Se algum estiver pago → SaleFinanciallyLockedException.
-     *
-     *   Passo 2 — Estorno de biomassa
-     *             Cria contra-lançamento IN no livro-razão e soft-delete
-     *             na transação OUT original, restaurando o saldo do stocking.
-     *
-     *   Passo 3 — Reabertura de ciclo de vida
-     *             Se a venda era is_total_harvest=true e fechou o stocking/batch,
-     *             reabre ambos (e o tank associado, se necessário).
-     *
-     *   Passo 4 — Soft delete da venda
+     * @throws \App\Domain\Exceptions\SaleFinanciallyLockedException
      */
     public function execute(string $id): void
     {
-        DB::transaction(function () use ($id): void {
-            // Lock pessimista — evita deleção concorrente ou edição simultânea
-            /** @var Sale $sale */
-            $sale = $this->saleRepository->findOrFailLocked($id);
+        DB::transaction(
+            function () use ($id): void {
+                // Lock pessimista — evita cancelamento concorrente
+                $sale = $this->saleRepository->findOrFailLocked($id);
 
-            // ── Passo 1: Cancela recebíveis ───────────────────────────────────
-            // Verificação ANTES de qualquer outra ação — se estiver pago, para aqui
-            $this->cancelReceivables->execute((string) $sale->id);
-
-            // ── Passo 2: Estorno de biomassa ──────────────────────────────────
-            // Cria contra-lançamento IN e soft-delete no OUT original
-            $this->revertBiomassOutflow->execute($sale);
-
-            // ── Passo 3: Reabertura do ciclo de vida ──────────────────────────
-            if ($sale->stocking_id !== null && (bool) $sale->is_total_harvest) {
-                $stocking = $this->resolveLockedStocking((string) $sale->stocking_id);
-
-                // Só reabre se ainda estiver fechado
-                // (outra venda posterior pode já ter reaberto)
-                if ($stocking->isClosed()) {
-                    $this->reopenStockingAndBatch->execute(
-                        $stocking,
-                        (string) $sale->batch_id,
-                    );
-                }
+                $this->cancelSale->execute($sale);
             }
-
-            // ── Passo 4: Cancela a venda ──────────────────────────────────────
-            $this->saleRepository->update((string) $sale->id, [
-                'status' => SaleStatus::CANCELLED,
-            ]);
-        });
-    }
-
-    /**
-     * Busca o stocking com lock pessimista via repositório.
-     */
-    private function resolveLockedStocking(string $stockingId): Stocking
-    {
-        return $this->stockingRepository->findOrFailLocked($stockingId);
+        );
     }
 }

--- a/app/Application/UseCases/Sale/ProcessHarvestSaleUseCase.php
+++ b/app/Application/UseCases/Sale/ProcessHarvestSaleUseCase.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Application\UseCases\Sale;
 
 use App\Application\Actions\Client\GuardClientCreditAction;
-use App\Application\Actions\Sale\GenerateReceivableAction;
+use App\Application\Actions\FinancialTransaction\GenerateReceivableAction;
 use App\Application\Actions\Sale\GuardBiomassAction;
 use App\Application\Actions\Sale\GuardClientFiscalDataAction;
 use App\Application\Actions\Sale\HarvestLifecycleAction;
@@ -15,7 +15,6 @@ use App\Application\DTOs\HarvestSaleDTO;
 use App\Domain\Events\SaleProcessed;
 use App\Domain\Exceptions\ClosedStockingException;
 use App\Domain\Models\Sale;
-use App\Domain\Models\Stocking;
 use App\Domain\Repositories\SaleRepositoryInterface;
 use App\Domain\Repositories\StockingRepositoryInterface;
 use Illuminate\Support\Facades\DB;
@@ -23,31 +22,20 @@ use Illuminate\Support\Facades\DB;
 /**
  * Orquestra o fluxo completo de despesca e venda.
  *
- * Regras de negócio aplicadas (em ordem):
- *   1. stocking_id obrigatório — garantido pela SaleStoreRequest (required).
- *   2. Stocking não pode estar fechado.
- *   3. Dados fiscais do cliente (se needs_invoice = true).
- *   4. Limite de crédito do cliente.
- *   5. Biomassa disponível com tolerância de 50% (constante de domínio).
- *   6. Persistência da venda.
- *   7. Baixa de biomassa com CMV exato (RegisterBiomassOutflowAction).
- *   8. Ciclo de vida stocking/batch se is_total_harvest = true (HarvestLifecycleAction).
- *   9. Geração de Contas a Receber (GenerateReceivableAction).
- *  10. Evento SaleProcessed disparado após commit → GenerateStockingHistory.
- *
- * Mudanças em relação à versão anterior:
- *   - Stocking carregado via StockingRepositoryInterface (não mais Stocking::findOrFail diretamente).
- *   - CloseStockingAndBatchAction substituída por HarvestLifecycleAction (unificação create/update).
- *   - HarvestSaleDTO construído com fromValidated() em vez de fromArray() — normalização feita na Request.
- *   - StockingRequiredException removida: stocking_id é `required` na Request, nunca chega null aqui.
- *   - company_id resolvido antes de construir o DTO, mantendo o DTO sem dependência do resolver.
+ * Regras aplicadas em ordem:
+ *  1. stocking_id obrigatório — garantido pela SaleStoreRequest (required).
+ *  2. Stocking não pode estar fechado.
+ *  3. Dados fiscais do cliente (se needs_invoice = true).
+ *  4. Limite de crédito do cliente.
+ *  5. Biomassa disponível com tolerância de 50%.
+ *  6. Persistência da venda.
+ *  7. Baixa de biomassa com CMV exato (RegisterBiomassOutflowAction).
+ *  8. Ciclo de vida stocking/batch se is_total_harvest = true (HarvestLifecycleAction).
+ *  9. Contas a Receber (GenerateReceivableAction).
+ * 10. Evento SaleProcessed após commit.
  */
 final readonly class ProcessHarvestSaleUseCase
 {
-    /**
-     * Regra 5: tolerância máxima acima da biomassa estimada permitida na despesca.
-     * Constante de domínio — não lida do payload.
-     */
     private const float BIOMASS_TOLERANCE_PERCENT = 50.0;
 
     public function __construct(
@@ -64,18 +52,11 @@ final readonly class ProcessHarvestSaleUseCase
     }
 
     /**
-     * @param array<string, mixed> $data Array validado e normalizado pela SaleStoreRequest.
-     *
-     * @throws ClosedStockingException
-     * @throws \App\Domain\Exceptions\ClientMissingFiscalDataException
-     * @throws \App\Domain\Exceptions\ClientCreditLimitExceededException
-     * @throws \App\Domain\Exceptions\InsufficientBiomassException
+     * @param array<string, mixed> $data
      */
     public function execute(array $data): Sale
     {
-        $data['company_id'] = $this->companyResolver->resolve(
-            hint: $data['company_id'] ?? null,
-        );
+        $data['company_id'] = $this->companyResolver->resolve(hint: $data['company_id'] ?? null);
 
         $dto = HarvestSaleDTO::fromValidated($data);
 
@@ -84,14 +65,14 @@ final readonly class ProcessHarvestSaleUseCase
 
     private function process(HarvestSaleDTO $dto): Sale
     {
-        // ── 1. Carrega e valida o stocking ────────────────────────────────────
+        // ── 1. Stocking ───────────────────────────────────────────────────────
         $stocking = $this->stockingRepository->findOrFail($dto->stockingId);
 
         if ($stocking->isClosed()) {
             throw new ClosedStockingException($stocking->id);
         }
 
-        // ── 2. Validações pré-persistência (sem escrita no banco) ─────────────
+        // ── 2. Validações pré-persistência ────────────────────────────────────
         $this->guardFiscalData->execute($dto->clientId, $dto->needsInvoice);
         $this->guardClientCredit->execute($dto->clientId, $dto->totalRevenue());
         $this->guardBiomass->executeWithTolerance(
@@ -100,11 +81,10 @@ final readonly class ProcessHarvestSaleUseCase
             tolerancePercent: self::BIOMASS_TOLERANCE_PERCENT,
         );
 
-        // ── 3. Persiste a venda ───────────────────────────────────────────────
+        // ── 3. Venda ──────────────────────────────────────────────────────────
         $sale = $this->saleRepository->create($dto->toSaleInputDTO());
 
-        // ── 4. Baixa de biomassa com CMV exato (Regra 3) ─────────────────────
-        // Peso já vendido ANTES desta venda (exclui a atual para não contaminar o CMV)
+        // ── 4. Baixa de biomassa com CMV exato ────────────────────────────────
         $alreadySoldWeight = $this->saleRepository->soldWeightByStocking(
             stockingId:    $dto->stockingId,
             excludeSaleId: (string) $sale->id,
@@ -112,8 +92,7 @@ final readonly class ProcessHarvestSaleUseCase
 
         $this->registerOutflow->execute($stocking, $sale, $alreadySoldWeight);
 
-        // ── 5. Ciclo de vida stocking/batch (Regra 4) ─────────────────────────
-        // HarvestLifecycleAction é idempotente: oldHarvest=false, newHarvest=dto->isHarvestTotal
+        // ── 5. Ciclo de vida stocking/batch ───────────────────────────────────
         if ($dto->isHarvestTotal) {
             $this->harvestLifecycle->apply(
                 stocking:          $stocking,
@@ -123,10 +102,10 @@ final readonly class ProcessHarvestSaleUseCase
             );
         }
 
-        // ── 6. Contas a Receber (Regra 5) ─────────────────────────────────────
-        $this->generateReceivable->execute($dto->toSaleInputDTO(), $sale);
+        // ── 6. Contas a Receber ───────────────────────────────────────────────
+        // Assinatura correta: (SaleInputDTO, Sale) — não (SaleInputDTO, string)
+        $this->generateReceivable->execute($dto->toSaleInputDTO(), (string) $sale->id);
 
-        // Disparado após commit — listener GenerateStockingHistory cria o histórico
         SaleProcessed::dispatch($sale);
 
         return $sale;

--- a/app/Application/UseCases/SalesOrder/CancelSalesOrderUseCase.php
+++ b/app/Application/UseCases/SalesOrder/CancelSalesOrderUseCase.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesOrder;
+
+use App\Application\Actions\Sale\CancelSaleAction;
+use App\Domain\Enums\SalesOrderStatus;
+use App\Domain\Exceptions\SalesOrderNotCancellableException;
+use App\Domain\Repositories\SaleRepositoryInterface;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+
+final readonly class CancelSalesOrderUseCase
+{
+    public function __construct(
+        private SalesOrderRepositoryInterface $salesOrderRepository,
+        private SaleRepositoryInterface $saleRepository,
+        private CancelSaleAction $cancelSale,
+    ) {
+    }
+
+    /**
+     * Cancela o pedido e todas as vendas vinculadas em uma única transação.
+     *
+     * Ordem de operações:
+     *  1. Verifica se o pedido pode ser cancelado (fail-fast fora da transação)
+     *  2. Abre transação única — evita transações aninhadas por venda
+     *  3. Para cada venda: delega para CancelSaleAction (mesma lógica do CancelSaleUseCase)
+     *  4. Atualiza status do pedido
+     *
+     * @throws SalesOrderNotCancellableException
+     * @throws \App\Domain\Exceptions\SaleFinanciallyLockedException Se qualquer venda estiver paga
+     */
+    public function execute(string $orderId): void
+    {
+        $order = $this->salesOrderRepository->findOrFail($orderId);
+
+        // Fail-fast fora da transação — sem custo de lock se o pedido não pode ser cancelado
+        if (! $order->canBeCancelled()) {
+            throw new SalesOrderNotCancellableException($orderId);
+        }
+
+        DB::transaction(
+            function () use ($order, $orderId): void {
+                // Todas as vendas do pedido em uma única query
+                $sales = $this->saleRepository->findByOrderId((string) $order->id);
+
+                foreach ($sales as $sale) {
+                    // Delega os 4 passos para CancelSaleAction
+                    // Não abre sub-transação — já estamos dentro da transação do pedido
+                    $this->cancelSale->execute($sale);
+                }
+
+                // Atualiza o pedido após todas as vendas canceladas com sucesso
+                $this->salesOrderRepository->update(
+                    $orderId,
+                    [
+                    'status' => SalesOrderStatus::CANCELLED->value,
+                    ]
+                );
+            }
+        );
+    }
+}

--- a/app/Application/UseCases/SalesOrder/CreateSalesOrderUseCase.php
+++ b/app/Application/UseCases/SalesOrder/CreateSalesOrderUseCase.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesOrder;
+
+use App\Application\Actions\Client\GuardClientCreditAction;
+use App\Application\Actions\FinancialTransaction\GenerateReceivableAction;
+use App\Application\Actions\Sale\GuardBiomassAction;
+use App\Application\Actions\Sale\GuardClientFiscalDataAction;
+use App\Application\Actions\Sale\RegisterBiomassOutflowAction;
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Application\DTOs\SaleInputDTO;
+use App\Application\DTOs\SalesOrderDTO;
+use App\Domain\Enums\SalesOrderType;
+use App\Domain\Enums\SaleStatus;
+use App\Domain\Events\SaleProcessed;
+use App\Domain\Exceptions\ClosedStockingException;
+use App\Domain\Models\Sale;
+use App\Domain\Models\SalesOrder;
+use App\Domain\Models\Stocking;
+use App\Domain\Repositories\SaleRepositoryInterface;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+use App\Domain\Repositories\StockingRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+
+final readonly class CreateSalesOrderUseCase
+{
+    private const float BIOMASS_TOLERANCE_PERCENT = 50.0;
+
+    public function __construct(
+        private CompanyResolverInterface $companyResolver,
+        private SalesOrderRepositoryInterface $salesOrderRepository,
+        private StockingRepositoryInterface $stockingRepository,
+        private SaleRepositoryInterface $saleRepository,
+        private GuardBiomassAction $guardBiomass,
+        private GuardClientFiscalDataAction $guardClientFiscalData,
+        private GuardClientCreditAction $guardClientCredit,
+        private RegisterBiomassOutflowAction $registerOutflow,
+        private GenerateReceivableAction $generateReceivable,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function execute(array $data): SalesOrder
+    {
+        $data['company_id'] = $this->companyResolver->resolve(hint: $data['company_id'] ?? null);
+        $data['type']       = SalesOrderType::ORDER->value;
+
+        $dto = SalesOrderDTO::fromArray($data);
+
+        // ── Passo 1: Validações — zero escritas no banco ───────────────────────
+        $this->guardClientFiscalData->execute($dto->clientId, $dto->needsInvoice);
+        $this->guardClientCredit->execute($dto->clientId, $dto->totalAmount());
+
+        $validatedItems = $this->resolveAndValidateStockings($dto);
+
+        // ── Passo 2: Persistência atômica ─────────────────────────────────────
+        return DB::transaction(fn (): SalesOrder => $this->persist($dto, $validatedItems));
+    }
+
+    /**
+     * @return array<int, array{saleInputDTO: SaleInputDTO, stocking: Stocking}>
+     */
+    private function resolveAndValidateStockings(SalesOrderDTO $dto): array
+    {
+        $validated = [];
+
+        foreach ($dto->items as $item) {
+            $stocking = $this->stockingRepository->findOrFail($item->stockingId);
+
+            if ($stocking->isClosed()) {
+                throw new ClosedStockingException($stocking->id);
+            }
+
+            $this->guardBiomass->executeWithTolerance(
+                stocking:         $stocking,
+                requestedWeight:  $item->quantity,
+                tolerancePercent: self::BIOMASS_TOLERANCE_PERCENT,
+            );
+
+            $saleInputDTO = new SaleInputDTO(
+                companyId:           $dto->companyId,
+                clientId:            $dto->clientId,
+                batchId:             (string) $stocking->batch_id,
+                totalWeight:         $item->quantity,
+                pricePerKg:          $item->unitPrice,
+                saleDate:            now()->format('Y-m-d'),
+                stockingId:          (string) $stocking->id,
+                financialCategoryId: $dto->financialCategoryId,
+                status:              SaleStatus::PENDING,
+                notes:               $dto->notes,
+            );
+
+            $validated[] = ['saleInputDTO' => $saleInputDTO, 'stocking' => $stocking];
+        }
+
+        return $validated;
+    }
+
+    /**
+     * @param array<int, array{saleInputDTO: SaleInputDTO, stocking: Stocking}> $validatedItems
+     */
+    private function persist(SalesOrderDTO $dto, array $validatedItems): SalesOrder
+    {
+        $order = $this->salesOrderRepository->createWithItems($dto);
+
+        /**
+ * @var Sale[] $createdSales
+*/
+        $createdSales = [];
+
+        foreach ($validatedItems as ['saleInputDTO' => $saleInputDTO, 'stocking' => $stocking]) {
+            $sale = $this->saleRepository->create($saleInputDTO);
+
+            $alreadySoldWeight = $this->saleRepository->soldWeightByStocking(
+                stockingId:    (string) $stocking->id,
+                excludeSaleId: (string) $sale->id,
+            );
+
+            $this->registerOutflow->execute($stocking, $sale, $alreadySoldWeight);
+
+            // Assinatura correta: GenerateReceivableAction::execute(SaleInputDTO, Sale)
+            // Não (string) $sale->id — o Model é necessário para compor a descrição do recebível
+            $this->generateReceivable->execute($saleInputDTO, (string) $sale->id);
+
+            $createdSales[] = $sale;
+        }
+
+        foreach ($createdSales as $sale) {
+            SaleProcessed::dispatch($sale);
+        }
+
+        return $order;
+    }
+}

--- a/app/Application/UseCases/SalesOrder/DeleteSalesOrderUseCase.php
+++ b/app/Application/UseCases/SalesOrder/DeleteSalesOrderUseCase.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesOrder;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Domain\Exceptions\SalesOrderDeleteForbiddenException;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+
+final readonly class DeleteSalesOrderUseCase
+{
+    public function __construct(
+        private SalesOrderRepositoryInterface $repository,
+        private CompanyResolverInterface $companyResolver,
+    ) {
+    }
+
+    public function execute(string $id): void
+    {
+        DB::transaction(function () use ($id): void {
+            $companyId = $this->companyResolver->resolve();
+            $order     = $this->repository->findForCompanyOrFail($id, $companyId);
+
+            if (! $order->status->allowsQuotationEditing()) {
+                throw SalesOrderDeleteForbiddenException::forStatus($order->status);
+            }
+
+            $order->delete();
+        });
+    }
+}

--- a/app/Application/UseCases/SalesOrder/ListSalesOrdersUseCase.php
+++ b/app/Application/UseCases/SalesOrder/ListSalesOrdersUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesOrder;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Domain\Enums\SalesOrderType;
+use App\Domain\Repositories\PaginationInterface;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+
+final readonly class ListSalesOrdersUseCase
+{
+    public function __construct(
+        private SalesOrderRepositoryInterface $repository,
+        private CompanyResolverInterface $companyResolver,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $filters clientId, status, type, perPage, page
+     */
+    public function execute(array $filters = []): PaginationInterface
+    {
+        $filters['companyId'] = $this->companyResolver->resolve();
+        $filters['type']      = SalesOrderType::ORDER->value;
+
+        return $this->repository->paginate($filters);
+    }
+}

--- a/app/Application/UseCases/SalesOrder/ShowSalesOrderUseCase.php
+++ b/app/Application/UseCases/SalesOrder/ShowSalesOrderUseCase.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesOrder;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Domain\Models\SalesOrder;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+
+final readonly class ShowSalesOrderUseCase
+{
+    public function __construct(
+        private SalesOrderRepositoryInterface $repository,
+        private CompanyResolverInterface $companyResolver,
+    ) {
+    }
+
+    public function execute(string $id): SalesOrder
+    {
+        $companyId = $this->companyResolver->resolve();
+
+        return $this->repository->findForCompanyOrFail($id, $companyId);
+    }
+}

--- a/app/Application/UseCases/SalesOrder/UpdateSalesOrderUseCase.php
+++ b/app/Application/UseCases/SalesOrder/UpdateSalesOrderUseCase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesOrder;
+
+use App\Domain\Models\SalesOrder;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+
+final readonly class UpdateSalesOrderUseCase
+{
+    public function __construct(
+        private SalesOrderRepositoryInterface $salesOrderRepository,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function execute(string $id, array $data): SalesOrder
+    {
+        $order = $this->salesOrderRepository->findOrFail($id);
+
+        $order->update($data);
+
+        return $order;
+    }
+}

--- a/app/Application/UseCases/SalesQuotation/ConvertQuotationToOrderUseCase.php
+++ b/app/Application/UseCases/SalesQuotation/ConvertQuotationToOrderUseCase.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesQuotation;
+
+use App\Application\Actions\Client\GuardClientCreditAction;
+use App\Application\Actions\FinancialTransaction\GenerateReceivableAction;
+use App\Application\Actions\Sale\GuardBiomassAction;
+use App\Application\Actions\Sale\GuardClientFiscalDataAction;
+use App\Application\Actions\Sale\RegisterBiomassOutflowAction;
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Application\DTOs\ConvertQuotationDTO;
+use App\Application\DTOs\SaleInputDTO;
+use App\Domain\Enums\SalesOrderStatus;
+use App\Domain\Enums\SalesOrderType;
+use App\Domain\Enums\SaleStatus;
+use App\Domain\Events\SaleProcessed;
+use App\Domain\Exceptions\ClosedStockingException;
+use App\Domain\Models\Sale;
+use App\Domain\Models\SalesOrder;
+use App\Domain\Models\Stocking;
+use App\Domain\Repositories\SaleRepositoryInterface;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+use App\Domain\Repositories\StockingRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+final readonly class ConvertQuotationToOrderUseCase
+{
+    private const float BIOMASS_TOLERANCE_PERCENT = 50.0;
+
+    public function __construct(
+        private SalesOrderRepositoryInterface $salesOrderRepository,
+        private StockingRepositoryInterface $stockingRepository,
+        private SaleRepositoryInterface $saleRepository,
+        private GuardBiomassAction $guardBiomass,
+        private GuardClientFiscalDataAction $guardClientFiscalData,
+        private GuardClientCreditAction $guardClientCredit,
+        private RegisterBiomassOutflowAction $registerOutflow,
+        private GenerateReceivableAction $generateReceivable,
+        private CompanyResolverInterface $companyResolver,
+    ) {
+    }
+
+    /**
+     * @param string               $quotationId ID do orçamento a ser
+     *                                          convertido
+     * @param array<string, mixed> $overrides Payload validado com dados
+     *                                        adicionais (ex: needsInvoice, financialCategoryId)
+     */
+    public function execute(string $quotationId, array $overrides): SalesOrder
+    {
+        $companyId = $this->companyResolver->resolve(
+            isset($overrides['company_id']) && is_string($overrides['company_id'])
+                ? $overrides['company_id']
+                : (isset($overrides['companyId']) && is_string($overrides['companyId'])
+                    ? $overrides['companyId']
+                    : null),
+        );
+
+        $quotation = $this->salesOrderRepository->findForCompanyOrFail($quotationId, $companyId);
+
+        // 2. Guardrail de Domínio (Fail Fast)
+        $this->ensureCanBeConverted($quotation);
+
+        // O DTO absorve os dados que faltavam no orçamento original mas são exigidos no Pedido
+        $dto = ConvertQuotationDTO::fromArray($overrides);
+
+        // ── Passo 1: Validações — zero escritas no banco ───────────────────────
+        $this->guardClientFiscalData->execute($quotation->client_id, $dto->needsInvoice);
+        $this->guardClientCredit->execute($quotation->client_id, (float) $quotation->total_amount);
+
+        // Valida se os peixes ainda estão nos tanques desde que o orçamento foi feito
+        $validatedItems = $this->resolveAndValidateStockings($quotation, $dto);
+
+        // ── Passo 2: Persistência atômica ─────────────────────────────────────
+        return DB::transaction(fn (): SalesOrder => $this->persistConversion($quotation, $validatedItems, $dto));
+    }
+
+    private function ensureCanBeConverted(SalesOrder $quotation): void
+    {
+        if ($quotation->type->value !== SalesOrderType::QUOTATION->value) {
+            throw new InvalidArgumentException('Document is not a quotation or has already been converted.');
+        }
+
+        // Se houver lógica de validade, entra aqui:
+        if ($quotation->expiration_date && $quotation->expiration_date->isPast()) {
+            throw new InvalidArgumentException("Quotation {$quotation->id} has expired.");
+        }
+    }
+
+    /**
+     * @return array<int, array{saleInputDTO: SaleInputDTO, stocking: Stocking}>
+     */
+    private function resolveAndValidateStockings(SalesOrder $quotation, ConvertQuotationDTO $dto): array
+    {
+        $validated = [];
+
+        // Itera sobre os itens já existentes no orçamento
+        foreach ($quotation->items as $item) {
+            $stocking = $this->stockingRepository->findOrFail($item->stocking_id);
+
+            if ($stocking->isClosed()) {
+                throw new ClosedStockingException($stocking->id);
+            }
+
+            $this->guardBiomass->executeWithTolerance(
+                stocking:         $stocking,
+                requestedWeight:  (float) $item->quantity,
+                tolerancePercent: self::BIOMASS_TOLERANCE_PERCENT,
+            );
+
+            // Monta o DTO combinando dados do Orçamento antigo com os novos inputs (overrides)
+            $saleInputDTO = new SaleInputDTO(
+                companyId:           $quotation->company_id,
+                clientId:            $quotation->client_id,
+                batchId:             (string) $stocking->batch_id,
+                totalWeight:         (float) $item->quantity,
+                pricePerKg:          (float) $item->unit_price,
+                saleDate:            $dto->expectedPaymentDate,
+                stockingId:          (string) $stocking->id,
+                financialCategoryId: $dto->financialCategoryId,
+                status:              SaleStatus::PENDING,
+                notes:               $dto->notes ?? $quotation->notes,
+            );
+
+            $validated[] = [
+                'saleInputDTO' => $saleInputDTO,
+                'stocking'     => $stocking,
+            ];
+        }
+
+        return $validated;
+    }
+
+    /**
+     * @param array<int, array{saleInputDTO: SaleInputDTO, stocking: Stocking}> $validatedItems
+     */
+    private function persistConversion(
+        SalesOrder $quotation,
+        array $validatedItems,
+        ConvertQuotationDTO $dto,
+    ): SalesOrder {
+        $order = $this->salesOrderRepository->update(
+            (string) $quotation->id,
+            [
+            'type'                   => SalesOrderType::ORDER->value,
+            'expected_delivery_date' => $dto->expectedDeliveryDate,
+            'status'                 => SalesOrderStatus::OPEN->value,
+            ]
+        );
+
+        /** @var Sale[] $createdSales */
+        $createdSales = [];
+
+        // 2. Os Side-Effects são idênticos aos do CreateSalesOrderUseCase
+        foreach ($validatedItems as ['saleInputDTO' => $saleInputDTO, 'stocking' => $stocking]) {
+            $sale = $this->saleRepository->create($saleInputDTO);
+
+            $alreadySoldWeight = $this->saleRepository->soldWeightByStocking(
+                stockingId:    (string) $stocking->id,
+                excludeSaleId: (string) $sale->id,
+            );
+
+            $this->registerOutflow->execute($stocking, $sale, $alreadySoldWeight);
+
+            $this->generateReceivable->execute($saleInputDTO, (string) $sale->id);
+
+            $createdSales[] = $sale;
+        }
+
+        // 3. Disparo de eventos coletados
+        foreach ($createdSales as $sale) {
+            SaleProcessed::dispatch($sale);
+        }
+
+        return $order;
+    }
+}

--- a/app/Application/UseCases/SalesQuotation/CreateSalesQuotationUseCase.php
+++ b/app/Application/UseCases/SalesQuotation/CreateSalesQuotationUseCase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesQuotation;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Application\DTOs\SalesQuotationDTO;
+use App\Domain\Models\SalesOrder;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+
+final readonly class CreateSalesQuotationUseCase
+{
+    public function __construct(
+        private CompanyResolverInterface $companyResolver,
+        private SalesOrderRepositoryInterface $salesOrderRepository,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data Payload validado pelo FormRequest (snake_case)
+     */
+    public function execute(array $data): SalesOrder
+    {
+        // CompanyResolver pertence ao UseCase, não ao FormRequest
+        $data['company_id'] = $this->companyResolver->resolve(
+            hint: isset($data['company_id']) && is_string($data['company_id'])
+                ? $data['company_id']
+                : (isset($data['companyId']) && is_string($data['companyId'])
+                    ? $data['companyId']
+                    : null),
+        );
+
+        $dto = SalesQuotationDTO::fromArray($data);
+
+        return DB::transaction(
+            fn (): SalesOrder => $this->salesOrderRepository->createQuotationWithItems($dto)
+        );
+    }
+}

--- a/app/Application/UseCases/SalesQuotation/ListSalesQuotationsUseCase.php
+++ b/app/Application/UseCases/SalesQuotation/ListSalesQuotationsUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesQuotation;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Domain\Enums\SalesOrderType;
+use App\Domain\Repositories\PaginationInterface;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+
+final readonly class ListSalesQuotationsUseCase
+{
+    public function __construct(
+        private SalesOrderRepositoryInterface $repository,
+        private CompanyResolverInterface $companyResolver,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $filters clientId, status, type, perPage, page
+     */
+    public function execute(array $filters = []): PaginationInterface
+    {
+        $filters['companyId'] = $this->companyResolver->resolve();
+        $filters['type']      = SalesOrderType::QUOTATION->value;
+
+        return $this->repository->paginate($filters);
+    }
+}

--- a/app/Application/UseCases/SalesQuotation/ShowSalesQuotationUseCase.php
+++ b/app/Application/UseCases/SalesQuotation/ShowSalesQuotationUseCase.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesQuotation;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Domain\Models\SalesOrder;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+
+final readonly class ShowSalesQuotationUseCase
+{
+    public function __construct(
+        private SalesOrderRepositoryInterface $repository,
+        private CompanyResolverInterface $companyResolver,
+    ) {
+    }
+
+    public function execute(string $id): SalesOrder
+    {
+        $companyId = $this->companyResolver->resolve();
+
+        return $this->repository->findForCompanyOrFail($id, $companyId);
+    }
+}

--- a/app/Application/UseCases/SalesQuotation/UpdateSalesQuotationUseCase.php
+++ b/app/Application/UseCases/SalesQuotation/UpdateSalesQuotationUseCase.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\UseCases\SalesQuotation;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Application\DTOs\SalesOrderUpdateDTO;
+use App\Domain\Enums\SalesOrderType;
+use App\Domain\Models\SalesOrder;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+use Illuminate\Support\Facades\DB;
+
+final readonly class UpdateSalesQuotationUseCase
+{
+    public function __construct(
+        private SalesOrderRepositoryInterface $salesOrderRepository,
+        private CompanyResolverInterface $companyResolver,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data Dados validados pelo FormRequest (snake_case)
+     */
+    public function execute(string $id, array $data): SalesOrder
+    {
+        $order = $this->salesOrderRepository->findOrFail($id);
+
+        $data['company_id'] = $this->companyResolver->resolve(
+            hint: $data['company_id'] ?? null,
+        );
+
+        if ($order->type !== SalesOrderType::QUOTATION) {
+            throw new \InvalidArgumentException('Order is not a quotation');
+        }
+
+        $dto = SalesOrderUpdateDTO::fromArray($data);
+
+        return DB::transaction(function () use ($order, $dto): SalesOrder {
+            $updated = $this->salesOrderRepository->update($order->id, $dto->toScalarAttributes());
+            $this->salesOrderRepository->syncItems($updated, $dto->items);
+
+            return $updated->refresh();
+        });
+    }
+}

--- a/app/Domain/Enums/SalesOrderStatus.php
+++ b/app/Domain/Enums/SalesOrderStatus.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Enums;
+
+enum SalesOrderStatus: string
+{
+    case DRAFT     = 'draft';
+    case OPEN      = 'open';
+    case SENT      = 'sent';
+    case EXPIRED   = 'expired';
+    case PAID      = 'paid';
+    case APPROVED  = 'approved';
+    case CONFIRMED = 'confirmed';
+    case CANCELLED = 'cancelled';
+    case FINISHED  = 'finished';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::DRAFT     => 'Draft',
+            self::OPEN      => 'Open',
+            self::SENT      => 'Sent',
+            self::EXPIRED   => 'Expired',
+            self::APPROVED  => 'Approved',
+            self::CONFIRMED => 'Confirmed',
+            self::PAID      => 'Paid',
+            self::CANCELLED => 'Cancelled',
+            self::FINISHED  => 'Finished',
+        };
+    }
+
+    /**
+     * Orçamento ainda pode ter cabeçalho e itens alterados.
+     */
+    public function allowsQuotationEditing(): bool
+    {
+        return match ($this) {
+            self::DRAFT, self::OPEN => true,
+            default => false,
+        };
+    }
+}

--- a/app/Domain/Enums/SalesOrderType.php
+++ b/app/Domain/Enums/SalesOrderType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Enums;
+
+enum SalesOrderType: string
+{
+    case QUOTATION = 'quotation';
+    case ORDER     = 'order';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::QUOTATION => 'Quotation',
+            self::ORDER     => 'Order',
+        };
+    }
+}

--- a/app/Domain/Exceptions/SalesOrderDeleteForbiddenException.php
+++ b/app/Domain/Exceptions/SalesOrderDeleteForbiddenException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use App\Domain\Enums\SalesOrderStatus;
+use RuntimeException;
+
+final class SalesOrderDeleteForbiddenException extends RuntimeException
+{
+    public static function forStatus(SalesOrderStatus $status): self
+    {
+        return new self(
+            "Sales order in status [{$status->value}] cannot be deleted."
+        );
+    }
+}

--- a/app/Domain/Exceptions/SalesOrderNotCancellableException.php
+++ b/app/Domain/Exceptions/SalesOrderNotCancellableException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use RuntimeException;
+
+final class SalesOrderNotCancellableException extends RuntimeException
+{
+    public function __construct(string $orderId)
+    {
+        parent::__construct(
+            "The sales order \"{$orderId}\" cannot be cancelled anymore. "
+            . 'Only sales orders with status draft, pending or confirmed can be cancelled.'
+        );
+    }
+}

--- a/app/Domain/Exceptions/SalesQuotationCannotBeUpdatedException.php
+++ b/app/Domain/Exceptions/SalesQuotationCannotBeUpdatedException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Exceptions;
+
+use App\Domain\Enums\SalesOrderStatus;
+use RuntimeException;
+
+final class SalesQuotationCannotBeUpdatedException extends RuntimeException
+{
+    public static function forStatus(SalesOrderStatus $status): self
+    {
+        return new self(
+            "Quotation in status [{$status->value}] cannot be updated."
+        );
+    }
+}

--- a/app/Domain/Models/Batch.php
+++ b/app/Domain/Models/Batch.php
@@ -6,6 +6,7 @@ namespace App\Domain\Models;
 
 use App\Domain\Enums\BatchStatus;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 
@@ -78,6 +79,17 @@ class Batch extends BaseModel
     {
         /** @var BelongsTo<Tank, static> $relation */
         $relation = $this->belongsTo(Tank::class, 'tank_id');
+
+        return $relation;
+    }
+
+    /**
+     * @phpstan-return HasMany<SalesOrderItem, static>
+     */
+    public function salesOrderItems(): HasMany
+    {
+        /** @var HasMany<SalesOrderItem, static> $relation */
+        $relation = $this->hasMany(SalesOrderItem::class, 'batch_id');
 
         return $relation;
     }

--- a/app/Domain/Models/Client.php
+++ b/app/Domain/Models/Client.php
@@ -95,4 +95,15 @@ class Client extends BaseModel
 
         return $relation;
     }
+
+    /**
+     * @phpstan-return HasMany<SalesOrder, static>
+     */
+    public function salesOrders(): HasMany
+    {
+        /** @var HasMany<SalesOrder, static> $relation */
+        $relation = $this->hasMany(SalesOrder::class, 'client_id');
+
+        return $relation;
+    }
 }

--- a/app/Domain/Models/Sale.php
+++ b/app/Domain/Models/Sale.php
@@ -135,4 +135,13 @@ class Sale extends BaseModel
     {
         return round((float) $this->total_weight * (float) $this->price_per_kg, 2);
     }
+
+    /** @phpstan-return BelongsTo<SalesOrder, static> */
+    public function salesOrder(): BelongsTo
+    {
+        /** @var BelongsTo<SalesOrder, static> $relation */
+        $relation = $this->belongsTo(SalesOrder::class, 'sales_order_id');
+
+        return $relation;
+    }
 }

--- a/app/Domain/Models/SalesOrder.php
+++ b/app/Domain/Models/SalesOrder.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Models;
+
+use App\Domain\Enums\SalesOrderStatus;
+use App\Domain\Enums\SalesOrderType;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * @property string               $id
+ * @property string               $company_id
+ * @property string               $client_id
+ * @property SalesOrderType       $type
+ * @property SalesOrderStatus     $status
+ * @property string               $total_amount
+ * @property Carbon               $issue_date
+ * @property Carbon|null          $expiration_date
+ * @property string|null          $quotation_id
+ * @property string|null          $notes
+ * @property-read Company|null    $company
+ * @property-read Client|null     $client
+ * @property-read SalesOrder|null $quotation
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, SalesOrder> $ordersFromQuotation
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, SalesOrderItem> $items
+ * @property Carbon|null          $created_at
+ * @property Carbon|null          $updated_at
+ * @property Carbon|null          $deleted_at
+ */
+class SalesOrder extends BaseModel
+{
+    use SoftDeletes;
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $fillable = [
+        'id',
+        'company_id',
+        'client_id',
+        'type',
+        'status',
+        'total_amount',
+        'issue_date',
+        'expiration_date',
+        'expected_delivery_date',
+        'delivered_at',
+        'expected_payment_date',
+        'quotation_id',
+        'notes',
+    ];
+
+    /** @var array<string, string|class-string> */
+    protected $casts = [
+        'type'                   => SalesOrderType::class,
+        'status'                 => SalesOrderStatus::class,
+        'total_amount'           => 'decimal:2',
+        'issue_date'             => 'date:Y-m-d',
+        'expiration_date'        => 'date:Y-m-d',
+        'expected_delivery_date' => 'date:Y-m-d',
+        'delivered_at'           => 'datetime',
+        'expected_payment_date'  => 'date:Y-m-d',
+    ];
+
+    #[\Override]
+    protected static function booted(): void
+    {
+        static::creating(static function (SalesOrder $order): void {
+            $order->id ??= (string) Str::uuid();
+            $order->type ??= SalesOrderType::QUOTATION;
+            $order->status ??= SalesOrderStatus::DRAFT;
+        });
+    }
+
+    /** @phpstan-return BelongsTo<Company, static> */
+    public function company(): BelongsTo
+    {
+        /** @var BelongsTo<Company, static> $relation */
+        $relation = $this->belongsTo(Company::class, 'company_id');
+
+        return $relation;
+    }
+
+    /** @phpstan-return BelongsTo<Client, static> */
+    public function client(): BelongsTo
+    {
+        /** @var BelongsTo<Client, static> $relation */
+        $relation = $this->belongsTo(Client::class, 'client_id');
+
+        return $relation;
+    }
+
+    /** @phpstan-return BelongsTo<SalesOrder, static> */
+    public function quotation(): BelongsTo
+    {
+        /** @var BelongsTo<SalesOrder, static> $relation */
+        $relation = $this->belongsTo(self::class, 'quotation_id');
+
+        return $relation;
+    }
+
+    /** @phpstan-return HasMany<SalesOrder, static> */
+    public function ordersFromQuotation(): HasMany
+    {
+        /** @var HasMany<SalesOrder, static> $relation */
+        $relation = $this->hasMany(self::class, 'quotation_id');
+
+        return $relation;
+    }
+
+    /** @phpstan-return HasMany<SalesOrderItem, static> */
+    public function items(): HasMany
+    {
+        /** @var HasMany<SalesOrderItem, static> $relation */
+        $relation = $this->hasMany(SalesOrderItem::class, 'sales_order_id');
+
+        return $relation;
+    }
+
+    public function sales(): HasMany
+    {
+        /** @var HasMany<Sale, static> $relation */
+        $relation = $this->hasMany(Sale::class, 'sales_order_id');
+
+        return $relation;
+    }
+
+    public function canBeCancelled(): bool
+    {
+        return in_array($this->status, [
+            SalesOrderStatus::DRAFT,
+            SalesOrderStatus::OPEN,
+            SalesOrderStatus::CONFIRMED,
+        ], strict: true);
+    }
+}

--- a/app/Domain/Models/SalesOrderItem.php
+++ b/app/Domain/Models/SalesOrderItem.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * @property string           $id
+ * @property string           $sales_order_id
+ * @property string           $stocking_id
+ * @property string           $quantity
+ * @property string           $unit_price
+ * @property string           $subtotal
+ * @property string           $measure_unit
+ * @property-read SalesOrder|null $salesOrder
+ * @property-read Stocking|null      $stocking
+ * @property Carbon|null      $created_at
+ * @property Carbon|null      $updated_at
+ */
+class SalesOrderItem extends BaseModel
+{
+    protected $table = 'sales_order_items';
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $fillable = [
+        'id',
+        'sales_order_id',
+        'stocking_id',
+        'quantity',
+        'unit_price',
+        'subtotal',
+        'measure_unit',
+    ];
+
+    /** @var array<string, string|class-string> */
+    protected $casts = [
+        'quantity'   => 'decimal:3',
+        'unit_price' => 'decimal:2',
+        'subtotal'   => 'decimal:2',
+    ];
+
+    #[\Override]
+    protected static function booted(): void
+    {
+        static::creating(static function (SalesOrderItem $item): void {
+            $item->id ??= (string) Str::uuid();
+        });
+    }
+
+    /** @phpstan-return BelongsTo<SalesOrder, static> */
+    public function salesOrder(): BelongsTo
+    {
+        /** @var BelongsTo<SalesOrder, static> $relation */
+        $relation = $this->belongsTo(SalesOrder::class, 'sales_order_id');
+
+        return $relation;
+    }
+
+    /** @phpstan-return BelongsTo<Stocking, static> */
+    public function stocking(): BelongsTo
+    {
+        /** @var BelongsTo<Stocking, static> $relation */
+        $relation = $this->belongsTo(Stocking::class, 'stocking_id');
+
+        return $relation;
+    }
+}

--- a/app/Domain/Repositories/SaleRepositoryInterface.php
+++ b/app/Domain/Repositories/SaleRepositoryInterface.php
@@ -6,6 +6,7 @@ namespace App\Domain\Repositories;
 
 use App\Application\DTOs\SaleInputDTO;
 use App\Domain\Models\Sale;
+use Illuminate\Support\Collection;
 
 interface SaleRepositoryInterface
 {
@@ -59,4 +60,11 @@ interface SaleRepositoryInterface
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function findOrFailLocked(string $id): Sale;
+
+    /**
+     * Find sales by sales order ID.
+     *
+     * @return Collection<int, Sale>
+     */
+    public function findByOrderId(string $orderId): Collection;
 }

--- a/app/Domain/Repositories/SalesOrderRepositoryInterface.php
+++ b/app/Domain/Repositories/SalesOrderRepositoryInterface.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Repositories;
+
+use App\Application\DTOs\SalesOrderDTO;
+use App\Application\DTOs\SalesOrderItemDTO;
+use App\Application\DTOs\SalesQuotationDTO;
+use App\Domain\Models\SalesOrder;
+
+interface SalesOrderRepositoryInterface
+{
+    public function findOrFail(string $id): SalesOrder;
+
+    /**
+     * Order/quotation of the company with default relations (404 if not exists or is of another company).
+     */
+    public function findForCompanyOrFail(string $id, string $companyId): SalesOrder;
+
+    /**
+     * Persist the order and its items.
+     * No DB::transaction here — the transaction is responsibility of the UseCase.
+     */
+    public function createWithItems(SalesOrderDTO $dto): SalesOrder;
+
+    /**
+     * Persist the quotation (default type/status of quotation) and items in bulk insert.
+     */
+    public function createQuotationWithItems(SalesQuotationDTO $dto): SalesOrder;
+
+    /**
+     * Sync the collection of persisted items with the received DTOs:
+     * - remove items missing in the DTOs
+     * - update existing items
+     * - create new items
+     *
+     * @param SalesOrderItemDTO[] $itemDTOs
+     */
+    public function syncItems(SalesOrder $order, array $itemDTOs): void;
+
+    /**
+     * Replaces all persisted items with the received DTO collection.
+     *
+     * @param SalesOrderItemDTO[] $itemDTOs
+     */
+    public function replaceItems(SalesOrder $order, array $itemDTOs): void;
+
+    /**
+     * Update only scalar attributes of the header (without replacing items).
+     *
+     * @param array<string, mixed> $attributes
+     */
+    public function update(string $id, array $attributes): SalesOrder;
+
+    /**
+     * @param array{
+     *     companyId: string,
+     *     clientId?: string|null,
+     *     status?: string|null,
+     *     type?: string|null,
+     *     perPage?: int,
+     *     page?: int,
+     * } $filters
+     */
+    public function paginate(array $filters): PaginationInterface;
+}

--- a/app/Domain/Repositories/StockingRepositoryInterface.php
+++ b/app/Domain/Repositories/StockingRepositoryInterface.php
@@ -69,12 +69,12 @@ interface StockingRepositoryInterface
     /**
      * Find a stocking by batch ID.
      */
-    public function findByBatchId(string $batchId): ?Stocking;
+    public function findByBatchOrFail(string $batchId): ?Stocking;
 
     /**
      * Check if there are any active stockings in a batch.
      */
-    public function hasActiveStockingsInBatch(string $batchId, string $excludeStockingId = null): bool;
+    public function hasActiveStockingsInBatch(string $batchId, ?string $excludeStockingId = null): bool;
 
     /**
      * Get the total accumulated cost of a batch.

--- a/app/Infrastructure/Persistence/SaleRepository.php
+++ b/app/Infrastructure/Persistence/SaleRepository.php
@@ -9,6 +9,7 @@ use App\Domain\Enums\SaleStatus;
 use App\Domain\Models\Sale;
 use App\Domain\Repositories\PaginationInterface;
 use App\Domain\Repositories\SaleRepositoryInterface;
+use Illuminate\Support\Collection;
 
 final class SaleRepository implements SaleRepositoryInterface
 {
@@ -127,5 +128,18 @@ final class SaleRepository implements SaleRepositoryInterface
             'batch:id,name',
             'stocking',
         ])->whereKey($id)->lockForUpdate()->firstOrFail();
+    }
+
+    /**
+     * @return Collection<int, Sale>
+     */
+    public function findByOrderId(string $orderId): Collection
+    {
+        return Sale::with([
+            'company:id,name',
+            'client:id,name',
+            'batch:id,name',
+            'stocking',
+        ])->where('sales_order_id', $orderId)->get();
     }
 }

--- a/app/Infrastructure/Persistence/SalesOrderRepository.php
+++ b/app/Infrastructure/Persistence/SalesOrderRepository.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence;
+
+use App\Application\DTOs\SalesOrderDTO;
+use App\Application\DTOs\SalesOrderItemDTO;
+use App\Application\DTOs\SalesOrderUpdateDTO;
+use App\Application\DTOs\SalesQuotationDTO;
+use App\Domain\Enums\SalesOrderStatus;
+use App\Domain\Enums\SalesOrderType;
+use App\Domain\Models\SalesOrder;
+use App\Domain\Models\SalesOrderItem;
+use App\Domain\Repositories\PaginationInterface;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
+use Illuminate\Support\Str;
+
+final class SalesOrderRepository implements SalesOrderRepositoryInterface
+{
+    private const array DEFAULT_RELATIONS = [
+        'items.stocking:id,quantity,average_weight,estimated_biomass,accumulated_fixed_cost',
+        'client:id,name',
+        'company:id,name',
+    ];
+
+    public function findOrFail(string $id): SalesOrder
+    {
+        return SalesOrder::with(self::DEFAULT_RELATIONS)->findOrFail($id);
+    }
+
+    public function findForCompanyOrFail(string $id, string $companyId): SalesOrder
+    {
+        return SalesOrder::query()
+            ->with(self::DEFAULT_RELATIONS)
+            ->whereKey($id)
+            ->where('company_id', $companyId)
+            ->firstOrFail();
+    }
+
+    /**
+     * Persiste o pedido e seus itens sem abrir transação.
+     * A transação é controlada pelo UseCase que chamou este método.
+     *
+     * total_amount já vem calculado pelo DTO — o repositório não recalcula.
+     */
+    public function createWithItems(SalesOrderDTO $dto): SalesOrder
+    {
+        /** @var SalesOrder $order */
+        $order = SalesOrder::create($dto->toPersistence());
+
+        $items = array_map(
+            static fn (SalesOrderItemDTO $item): array => array_merge(
+                ['id' => (string) Str::uuid()],
+                $item->toPersistence((string) $order->id),
+            ),
+            $dto->items,
+        );
+
+        SalesOrderItem::insert($items);
+
+        return $order->load(self::DEFAULT_RELATIONS);
+    }
+
+    public function createQuotationWithItems(SalesQuotationDTO $dto): SalesOrder
+    {
+        /** @var SalesOrder $order */
+        $order = SalesOrder::create(array_merge($dto->toPersistence(), [
+            'type'   => SalesOrderType::QUOTATION->value,
+            'status' => SalesOrderStatus::DRAFT->value,
+        ]));
+
+        $items = array_map(
+            static fn (SalesOrderItemDTO $item): array => array_merge(
+                ['id' => (string) Str::uuid()],
+                $item->toPersistence((string) $order->id),
+            ),
+            $dto->items,
+        );
+
+        SalesOrderItem::insert($items);
+
+        return $order->load(self::DEFAULT_RELATIONS);
+    }
+
+    public function syncItems(SalesOrder $order, array $itemDTOs): void
+    {
+        $existing    = $order->items->keyBy('id');
+        $incomingIds = collect($itemDTOs)
+            ->map(static fn (SalesOrderItemDTO $dto): ?string => $dto->id)
+            ->filter()
+            ->values();
+
+        $existing
+            ->reject(static fn ($item): bool => $incomingIds->contains($item->id))
+            ->each(static fn ($item): bool => $item->delete());
+
+        foreach ($itemDTOs as $dto) {
+            if ($dto->id !== null && $existing->has($dto->id)) {
+                $existing->get($dto->id)->update($dto->toPersistence((string) $order->id));
+            }
+        }
+    }
+
+    public function replaceItems(SalesOrder $order, array $itemDTOs): void
+    {
+        $order->items()->delete();
+
+        if ($itemDTOs === []) {
+            return;
+        }
+
+        $rows = array_map(
+            static fn (SalesOrderItemDTO $item): array => array_merge(
+                ['id' => (string) Str::uuid()],
+                $item->toPersistence((string) $order->id),
+            ),
+            $itemDTOs,
+        );
+
+        SalesOrderItem::insert($rows);
+    }
+
+    public function updateQuotationWithItems(string $id, SalesOrderUpdateDTO $dto): SalesOrder
+    {
+        $order      = $this->findOrFail($id);
+        $attributes = $dto->toScalarAttributes();
+
+        if ($attributes !== []) {
+            $order->update($attributes);
+        }
+
+        // Substitui os itens apenas quando o payload incluiu 'items'
+        if ($dto->items !== null) {
+            // Delete dos itens atuais (soft-delete via Model ou hard-delete se sem deleted_at)
+            $order->items()->delete();
+
+            // Bulk insert dos novos itens
+            $rows = array_map(
+                static fn (SalesOrderItemDTO $item): array => array_merge(
+                    ['id' => (string) Str::uuid()],
+                    $item->toPersistence((string) $order->id),
+                ),
+                $dto->items,
+            );
+
+            SalesOrderItem::insert($rows);
+        }
+
+        return $order->refresh()->load(self::DEFAULT_RELATIONS);
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function update(string $id, array $attributes): SalesOrder
+    {
+        $order = $this->findOrFail($id);
+
+        if ($attributes !== []) {
+            $order->update($attributes);
+        }
+
+        return $order->refresh()->load(self::DEFAULT_RELATIONS);
+    }
+
+    public function paginate(array $filters): PaginationInterface
+    {
+        $paginator = SalesOrder::with(['client:id,name'])
+            ->where('company_id', $filters['companyId'])
+            ->when(
+                ! empty($filters['clientId']),
+                static fn ($q) => $q->where('client_id', $filters['clientId']),
+            )
+            ->when(
+                ! empty($filters['status']),
+                static fn ($q) => $q->where(
+                    'status',
+                    SalesOrderStatus::from((string) $filters['status'])->value,
+                ),
+            )
+            ->when(
+                ! empty($filters['type']),
+                static fn ($q) => $q->where(
+                    'type',
+                    SalesOrderType::from((string) $filters['type'])->value,
+                ),
+            )
+            ->orderByDesc('issue_date')
+            ->orderByDesc('id')
+            ->paginate((int) ($filters['perPage'] ?? 25));
+
+        return new PaginationPresentr($paginator);
+    }
+}

--- a/app/Infrastructure/Persistence/StockingRepository.php
+++ b/app/Infrastructure/Persistence/StockingRepository.php
@@ -153,16 +153,16 @@ final class StockingRepository implements StockingRepositoryInterface
             ->firstOrFail();
     }
 
-    public function findByBatchId(string $batchId): ?Stocking
+    public function findByBatchOrFail(string $batchId): Stocking
     {
         return Stocking::with(self::DEFAULT_RELATIONS)
             ->where('batch_id', $batchId)
             ->where('status', StockingStatus::ACTIVE)
             ->latest('stocking_date')
-            ->first();
+            ->firstOrFail();
     }
 
-    public function hasActiveStockingsInBatch(string $batchId, string $excludeStockingId = null): bool
+    public function hasActiveStockingsInBatch(string $batchId, ?string $excludeStockingId = null): bool
     {
         return Stocking::with(self::DEFAULT_RELATIONS)
             ->where('batch_id', $batchId)

--- a/app/Infrastructure/Providers/AppServiceProvider.php
+++ b/app/Infrastructure/Providers/AppServiceProvider.php
@@ -32,6 +32,7 @@ use App\Domain\Repositories\InventoryAdjustmentRepositoryInterface;
 use App\Domain\Repositories\MortalityRepositoryInterface;
 use App\Domain\Repositories\PurchaseRepositoryInterface;
 use App\Domain\Repositories\SaleRepositoryInterface;
+use App\Domain\Repositories\SalesOrderRepositoryInterface;
 use App\Domain\Repositories\SensorReadingRepositoryInterface;
 use App\Domain\Repositories\SensorRepositoryInterface;
 use App\Domain\Repositories\StockingHistoryRepositoryInterface;
@@ -63,6 +64,7 @@ use App\Infrastructure\Persistence\InventoryAdjustmentRepository;
 use App\Infrastructure\Persistence\MortalityRepository;
 use App\Infrastructure\Persistence\PurchaseRepository;
 use App\Infrastructure\Persistence\SaleRepository;
+use App\Infrastructure\Persistence\SalesOrderRepository;
 use App\Infrastructure\Persistence\SensorReadingRepository;
 use App\Infrastructure\Persistence\SensorRepository;
 use App\Infrastructure\Persistence\StockingHistoryRepository;
@@ -137,6 +139,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(MortalityRepositoryInterface::class, MortalityRepository::class);
         $this->app->bind(PurchaseRepositoryInterface::class, PurchaseRepository::class);
         $this->app->bind(SaleRepositoryInterface::class, SaleRepository::class);
+        $this->app->bind(SalesOrderRepositoryInterface::class, SalesOrderRepository::class);
         $this->app->bind(SensorRepositoryInterface::class, SensorRepository::class);
         $this->app->bind(
             SensorReadingRepositoryInterface::class,

--- a/app/Presentation/Controllers/SalesOrderController.php
+++ b/app/Presentation/Controllers/SalesOrderController.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Controllers;
+
+use App\Application\UseCases\SalesOrder\CancelSalesOrderUseCase;
+use App\Application\UseCases\SalesOrder\CreateSalesOrderUseCase;
+use App\Application\UseCases\SalesOrder\DeleteSalesOrderUseCase;
+use App\Application\UseCases\SalesOrder\ListSalesOrdersUseCase;
+use App\Application\UseCases\SalesOrder\ShowSalesOrderUseCase;
+use App\Application\UseCases\SalesOrder\UpdateSalesOrderUseCase;
+use App\Presentation\Requests\SalesOrder\SalesOrderStoreRequest;
+use App\Presentation\Requests\SalesOrder\SalesOrderUpdateRequest;
+use App\Presentation\Resources\SalesOrder\SalesOrderResource;
+use App\Presentation\Response\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * @OA\Tag(name="Sales orders", description="Pedidos")
+ */
+final class SalesOrderController
+{
+    /**
+     * @OA\Get(
+     *     path="/company/sales-orders",
+     *     summary="Lista pedidos/orçamentos da empresa",
+     *     tags={"Sales orders"},
+     *     security={{"bearerAuth":{}}},
+     * @OA\Parameter(name="clientId", in="query", required=false, @OA\Schema(type="string", format="uuid")),
+     * @OA\Parameter(name="status",   in="query", required=false, @OA\Schema(type="string")),
+     * @OA\Parameter(
+     *     name="type",
+     *     in="query",
+     *     required=false,
+     *     @OA\Schema(type="string", enum={"quotation","order"})
+     * ),
+     * @OA\Parameter(name="perPage",  in="query", required=false, @OA\Schema(type="integer", example=25)),
+     * @OA\Parameter(name="page",     in="query", required=false, @OA\Schema(type="integer", example=1)),
+     * @OA\Response(response=200,     description="Lista paginada"),
+     * @OA\Response(response=401,     description="Não autorizado")
+     * )
+     */
+    public function index(Request $request, ListSalesOrdersUseCase $useCase): JsonResponse
+    {
+        $paginator = $useCase->execute(
+            $request->only(
+                [
+                'clientId', 'status', 'type', 'perPage', 'page', 'companyId',
+                ]
+            ),
+        );
+
+        return ApiResponse::success(
+            data:       SalesOrderResource::collection($paginator->items()),
+            pagination: [
+                'total'        => $paginator->total(),
+                'current_page' => $paginator->currentPage(),
+                'last_page'    => $paginator->lastPage(),
+                'first_page'   => $paginator->firstPage(),
+                'per_page'     => $paginator->perPage(),
+            ],
+        );
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/company/sales-order/{id}",
+     *     summary="Detalhe de um pedido/orçamento",
+     *     tags={"Sales orders"},
+     *     security={{"bearerAuth":{}}},
+     * @OA\Parameter(name="id",   in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     * @OA\Response(response=200, description="Encontrado"),
+     * @OA\Response(response=404, description="Não encontrado"),
+     * @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function show(string $id, ShowSalesOrderUseCase $useCase): JsonResponse
+    {
+        $order = $useCase->execute($id);
+
+        return ApiResponse::success(SalesOrderResource::make($order));
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/company/sales-order/{id}",
+     *     summary="Remove (soft delete) pedido/orçamento em rascunho ou aberto",
+     *     tags={"Sales orders"},
+     *     security={{"bearerAuth":{}}},
+     * @OA\Parameter(name="id",   in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     * @OA\Response(response=200, description="Removido"),
+     * @OA\Response(response=404, description="Não encontrado"),
+     * @OA\Response(response=422, description="Status não permite exclusão"),
+     * @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function destroy(string $id, DeleteSalesOrderUseCase $useCase): JsonResponse
+    {
+        $useCase->execute($id);
+
+        return ApiResponse::success(
+            data:    null,
+            status:  JsonResponse::HTTP_OK,
+            message: 'Sales order deleted successfully.',
+        );
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/company/sale-order",
+     *     summary="Cria um pedido (order) com itens",
+     *     tags={"Sales orders"},
+     *     security={{"bearerAuth":{}}},
+     * @OA\Response(response=201, description="Pedido criado"),
+     * @OA\Response(response=422, description="Erro de validação"),
+     * @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function store(
+        SalesOrderStoreRequest $request,
+        CreateSalesOrderUseCase $useCase,
+    ): JsonResponse {
+        $order = $useCase->execute($request->validated());
+
+        return ApiResponse::created(
+            data:    SalesOrderResource::make($order),
+            message: 'Order created successfully.',
+        );
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/api/company/sale-order/{id}",
+     *     summary="Atualiza um pedido (order) com regras de validação do create",
+     *     tags={"Sales orders"},
+     *     security={{"bearerAuth":{}}},
+     * @OA\Parameter(name="id",   in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     * @OA\Response(response=200, description="Pedido atualizado"),
+     * @OA\Response(response=422, description="Erro de validação"),
+     * @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function update(
+        string $id,
+        SalesOrderUpdateRequest $request,
+        UpdateSalesOrderUseCase $useCase,
+    ): JsonResponse {
+        $order = $useCase->execute($id, $request->validated());
+
+        return ApiResponse::success(
+            data: SalesOrderResource::make($order),
+            message: 'Order updated successfully.',
+        );
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/company/sales-order/{id}/cancel",
+     *     summary="Cancela um pedido (order)",
+     *     tags={"Sales orders"},
+     *     security={{"bearerAuth":{}}},
+     * @OA\Parameter(name="id",   in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     * @OA\Response(response=200, description="Pedido cancelado"),
+     * @OA\Response(response=404, description="Não encontrado"),
+     * @OA\Response(response=422, description="Status não permite cancelamento"),
+     * @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function cancel(string $id, CancelSalesOrderUseCase $useCase): JsonResponse
+    {
+        $useCase->execute($id);
+
+        return ApiResponse::success(message: 'Sales order cancelled successfully.');
+    }
+}

--- a/app/Presentation/Controllers/SalesQuotationController.php
+++ b/app/Presentation/Controllers/SalesQuotationController.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Controllers;
+
+use App\Application\UseCases\SalesQuotation\ConvertQuotationToOrderUseCase;
+use App\Application\UseCases\SalesQuotation\CreateSalesQuotationUseCase;
+use App\Application\UseCases\SalesQuotation\ListSalesQuotationsUseCase;
+use App\Application\UseCases\SalesQuotation\ShowSalesQuotationUseCase;
+use App\Application\UseCases\SalesQuotation\UpdateSalesQuotationUseCase;
+use App\Presentation\Requests\SalesOrder\ConvertQuotationToOrderRequest;
+use App\Presentation\Requests\SalesOrder\SalesQuotationStoreRequest;
+use App\Presentation\Requests\SalesOrder\SalesQuotationUpdateRequest;
+use App\Presentation\Resources\SalesOrder\SalesOrderResource;
+use App\Presentation\Response\ApiResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * @OA\Tag(name="Sales quotations", description="Orçamentos (cotações)")
+ */
+final class SalesQuotationController
+{
+    /**
+     * @OA\Get(
+     *     path="/company/sale-orders/quotations",
+     *     summary="Lista orçamentos (cotações) da empresa",
+     *     tags={"Sales quotations"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="clientId", in="query", required=false, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Parameter(name="status", in="query", required=false, @OA\Schema(type="string")),
+     *     @OA\Parameter(name="perPage", in="query", required=false, @OA\Schema(type="integer", example=25)),
+     *     @OA\Parameter(name="page", in="query", required=false, @OA\Schema(type="integer", example=1)),
+     *     @OA\Response(response=200, description="Lista paginada"),
+     *     @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function index(Request $request, ListSalesQuotationsUseCase $useCase): JsonResponse
+    {
+        $paginator = $useCase->execute(
+            $request->only([
+                'clientId', 'status', 'type', 'perPage', 'page', 'companyId',
+            ]),
+        );
+
+        return ApiResponse::success(
+            data:       SalesOrderResource::collection($paginator->items()),
+            pagination: [
+                'total'        => $paginator->total(),
+                'current_page' => $paginator->currentPage(),
+                'last_page'    => $paginator->lastPage(),
+                'first_page'   => $paginator->firstPage(),
+                'per_page'     => $paginator->perPage(),
+            ],
+        );
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/company/sale-order/quotation/{id}",
+     *     summary="Detalhe de um orçamento (cotação)",
+     *     tags={"Sales quotations"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(response=200, description="Encontrado"),
+     *     @OA\Response(response=404, description="Não encontrado"),
+     *     @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function show(string $id, ShowSalesQuotationUseCase $useCase): JsonResponse
+    {
+        $order = $useCase->execute($id);
+
+        return ApiResponse::success(SalesOrderResource::make($order));
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/company/sale-order/quotation",
+     *     summary="Cria um orçamento (cotação) com itens",
+     *     tags={"Sales quotations"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"clientId", "issueDate", "expirationDate", "items"},
+     *             @OA\Property(property="companyId", type="string", format="uuid", nullable=true),
+     *             @OA\Property(property="clientId", type="string", format="uuid"),
+     *             @OA\Property(property="issueDate", type="string", format="date"),
+     *             @OA\Property(property="expirationDate", type="string", format="date"),
+     *             @OA\Property(property="notes", type="string", nullable=true),
+     *             @OA\Property(
+     *                 property="items",
+     *                 type="array",
+     *                 @OA\Items(
+     *                     type="object",
+     *                     required={"stockingId", "quantity", "unitPrice"},
+     *                     @OA\Property(property="stockingId", type="string", format="uuid"),
+     *                     @OA\Property(property="quantity", type="number", example=100.5),
+     *                     @OA\Property(property="unitPrice", type="number", example=18.9),
+     *                     @OA\Property(property="measureUnit", type="string", enum={"kg","g","un"}, nullable=true)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=201, description="Orçamento criado"),
+     *     @OA\Response(response=422, description="Erro de validação"),
+     *     @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function store(
+        SalesQuotationStoreRequest $request,
+        CreateSalesQuotationUseCase $useCase,
+    ): JsonResponse {
+        $order = $useCase->execute($request->validated());
+
+        return ApiResponse::created(
+            data:    SalesOrderResource::make($order),
+            message: 'Quotation created successfully.',
+        );
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/api/company/sale-order/quotation/{id}",
+     *     summary="Atualiza um orçamento",
+     *     tags={"Sales quotations"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="id", in="path", required=true,
+     *         @OA\Schema(type="string", format="uuid")
+     *     ),
+     *     @OA\RequestBody(
+     *         @OA\JsonContent(
+     *             @OA\Property(property="clientId",      type="string", format="uuid"),
+     *             @OA\Property(property="issueDate",     type="string", format="date"),
+     *             @OA\Property(property="expirationDate",type="string", format="date"),
+     *             @OA\Property(property="notes",         type="string", nullable=true),
+     *             @OA\Property(
+     *                 property="items",
+     *                 type="array",
+     *                 description="Quando enviado, substitui TODOS os itens existentes.",
+     *                 @OA\Items(
+     *                     required={"stockingId","quantity","unitPrice"},
+     *                     @OA\Property(property="stockingId", type="string", format="uuid"),
+     *                     @OA\Property(property="quantity",   type="number"),
+     *                     @OA\Property(property="unitPrice",  type="number"),
+     *                     @OA\Property(property="measureUnit",type="string", enum={"kg","g","un"}, nullable=true)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=200, description="Orçamento atualizado"),
+     *     @OA\Response(response=404, description="Não encontrado"),
+     *     @OA\Response(response=422, description="Erro de validação")
+     * )
+     */
+    public function update(
+        SalesQuotationUpdateRequest $request,
+        string $id,
+        UpdateSalesQuotationUseCase $useCase,
+    ): JsonResponse {
+        $order = $useCase->execute($id, $request->validated());
+
+        return ApiResponse::success(
+            data:    SalesOrderResource::make($order),
+            message: 'Quotation updated successfully.',
+        );
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/company/sale-order/quotation/{id}/convert",
+     *     summary="Converte um orçamento em pedido (vendas, baixa de biomassa, contas a receber)",
+     *     tags={"Sales quotations"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="string", format="uuid")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"expectedDeliveryDate","expectedPaymentDate","financialCategoryId","needsInvoice"},
+     *             @OA\Property(property="expectedDeliveryDate", type="string", format="date"),
+     *             @OA\Property(property="expectedPaymentDate", type="string", format="date"),
+     *             @OA\Property(property="financialCategoryId", type="string", format="uuid"),
+     *             @OA\Property(property="needsInvoice", type="boolean"),
+     *             @OA\Property(property="notes", type="string", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=200, description="Pedido gerado a partir do orçamento"),
+     *     @OA\Response(response=422, description="Erro de validação"),
+     *     @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function convert(
+        string $id,
+        ConvertQuotationToOrderRequest $request,
+        ConvertQuotationToOrderUseCase $useCase,
+    ): JsonResponse {
+        $order = $useCase->execute($id, $request->validated());
+
+        return ApiResponse::success(
+            data:    SalesOrderResource::make($order),
+            message: 'Quotation converted to order successfully.',
+        );
+    }
+}

--- a/app/Presentation/Exceptions/Handler.php
+++ b/app/Presentation/Exceptions/Handler.php
@@ -29,6 +29,8 @@ use App\Domain\Exceptions\InvalidSaleStatusTransitionException;
 use App\Domain\Exceptions\MortalityExceedsSurvivorsException;
 use App\Domain\Exceptions\MortalityNotFoundException;
 use App\Domain\Exceptions\SaleFinanciallyLockedException;
+use App\Domain\Exceptions\SalesOrderDeleteForbiddenException;
+use App\Domain\Exceptions\SalesQuotationCannotBeUpdatedException;
 use App\Domain\Exceptions\StockNotFoundException;
 use App\Domain\Exceptions\TankAlreadyHasActiveBatchException;
 use App\Domain\Exceptions\TransactionAlreadyAllocatedException;
@@ -95,6 +97,8 @@ class Handler extends ExceptionHandler
         ClosedStockingException::class,
         SaleFinanciallyLockedException::class,
         InvalidSaleStatusTransitionException::class,
+        SalesQuotationCannotBeUpdatedException::class,
+        SalesOrderDeleteForbiddenException::class,
         // CostAllocation
         TransactionAlreadyAllocatedException::class,
         AllocationAmountMismatchException::class,
@@ -324,6 +328,20 @@ class Handler extends ExceptionHandler
 
         $this->renderable(
             fn (InvalidSaleStatusTransitionException $e, Request $r): JsonResponse => $this->handleDomainException(
+                $e,
+                JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+            )
+        );
+
+        $this->renderable(
+            fn (SalesQuotationCannotBeUpdatedException $e, Request $r): JsonResponse => $this->handleDomainException(
+                $e,
+                JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+            )
+        );
+
+        $this->renderable(
+            fn (SalesOrderDeleteForbiddenException $e, Request $r): JsonResponse => $this->handleDomainException(
                 $e,
                 JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
             )

--- a/app/Presentation/Requests/SalesOrder/ConvertQuotationToOrderRequest.php
+++ b/app/Presentation/Requests/SalesOrder/ConvertQuotationToOrderRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Requests\SalesOrder;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class ConvertQuotationToOrderRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge($this->normalizeFields());
+    }
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'expected_delivery_date' => ['required', 'date_format:Y-m-d'],
+            'expected_payment_date'  => ['required', 'date_format:Y-m-d'],
+            'financial_category_id'  => ['required', 'uuid', 'exists:financial_categories,id'],
+            'needs_invoice'          => ['required', 'boolean'],
+            'notes'                  => ['nullable', 'string', 'max:65535'],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function normalizeFields(): array
+    {
+        return $this->mapCamelToSnake([
+            'expectedDeliveryDate' => 'expected_delivery_date',
+            'expectedPaymentDate'  => 'expected_payment_date',
+            'financialCategoryId'  => 'financial_category_id',
+            'needsInvoice'         => 'needs_invoice',
+        ]);
+    }
+
+    /**
+     * @param array<string, string> $map
+     * @param array<string, mixed>|null $source
+     *
+     * @return array<string, mixed>
+     */
+    private function mapCamelToSnake(array $map, ?array $source = null): array
+    {
+        $source ??= $this->all();
+        $normalized = [];
+
+        foreach ($map as $camel => $snake) {
+            if (array_key_exists($camel, $source) && ! array_key_exists($snake, $source)) {
+                $normalized[$snake] = $source[$camel];
+            }
+        }
+
+        return array_merge($source, $normalized);
+    }
+}

--- a/app/Presentation/Requests/SalesOrder/SalesOrderStoreRequest.php
+++ b/app/Presentation/Requests/SalesOrder/SalesOrderStoreRequest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Requests\SalesOrder;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class SalesOrderStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge(
+            array_merge(
+                $this->normalizeFields(),
+                $this->normalizeItems()
+            )
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'client_id'              => $this->clientRules(),
+            'issue_date'             => ['required', 'date_format:Y-m-d'],
+            'expected_payment_date'  => ['required', 'date_format:Y-m-d', 'after_or_equal:issue_date'],
+            'expected_delivery_date' => ['required', 'date_format:Y-m-d', 'after_or_equal:issue_date'],
+
+            'financial_category_id' => ['required', 'uuid', 'exists:financial_categories,id'],
+            'needs_invoice'         => ['required', 'boolean'],
+            'notes'                 => ['nullable', 'string', 'max:65535'],
+
+            'items'               => ['required', 'array', 'min:1'],
+            'items.*.stocking_id' => $this->stockingRules(),
+            'items.*.quantity'    => ['required', 'numeric', 'gt:0'],
+            'items.*.unit_price'  => ['required', 'numeric', 'min:0'],
+        ];
+    }
+
+    #[\Override]
+    public function messages(): array
+    {
+        return [
+            'client_id.required' => 'The client is required.',
+            'client_id.exists'   => 'The client does not belong to the company.',
+
+            'issue_date.required'    => 'The issue date is required.',
+            'issue_date.date_format' => 'The issue date must be a valid date.',
+
+            'expected_delivery_date.required'       => 'The expected delivery date is required.',
+            'expected_delivery_date.date_format'    => 'The expected delivery date must be a valid date.',
+            'expected_delivery_date.after_or_equal' =>
+                'The expected delivery date must be after or equal to issue date.',
+
+            'expected_payment_date.required'       => 'The expected payment date is required.',
+            'expected_payment_date.date_format'    => 'The expected payment date must be a valid date.',
+            'expected_payment_date.after_or_equal' =>
+                'The expected payment date must be after or equal to issue date.',
+
+            'financial_category_id.required' => 'The financial category is required.',
+            'financial_category_id.exists'   => 'The financial category does not belong to the company.',
+
+            'needs_invoice.required' => 'The needs invoice field is required.',
+            'needs_invoice.boolean'  => 'The needs invoice field must be true or false.',
+
+            'items.required'              => 'At least one item is required.',
+            'items.*.stocking_id.exists'  => 'Invalid stocking for this company.',
+            'items.*.quantity.required'   => 'The quantity is required.',
+            'items.*.quantity.numeric'    => 'The quantity must be a number.',
+            'items.*.quantity.gt'         => 'The quantity must be greater than zero.',
+            'items.*.unit_price.required' => 'The unit price is required.',
+            'items.*.unit_price.numeric'  => 'The unit price must be a number.',
+            'items.*.unit_price.min'      => 'The unit price must be greater than zero.',
+        ];
+    }
+
+    // =========================
+    // 🔹 Normalization Layer
+    // =========================
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeFields(): array
+    {
+        return $this->mapCamelToSnake(
+            [
+            'clientId'             => 'client_id',
+            'issueDate'            => 'issue_date',
+            'expectedPaymentDate'  => 'expected_payment_date',
+            'expectedDeliveryDate' => 'expected_delivery_date',
+            'needsInvoice'         => 'needs_invoice',
+            'financialCategoryId'  => 'financial_category_id',
+            ]
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeItems(): array
+    {
+        if (! $this->has('items') || ! is_array($this->input('items'))) {
+            return [];
+        }
+
+        return [
+            'items' => array_map(
+                fn (?array $item): array => $this->mapCamelToSnake(
+                    [
+                    'stockingId' => 'stocking_id',
+                    'unitPrice'  => 'unit_price',
+                    ],
+                    $item
+                ),
+                $this->input('items')
+            ),
+        ];
+    }
+
+    /**
+     * @param array<string, string>     $map
+     * @param array<string, mixed>|null $source
+     *
+     * @return array<string, mixed>
+     */
+    private function mapCamelToSnake(array $map, ?array $source = null): array
+    {
+        $source ??= $this->all();
+        $normalized = [];
+
+        foreach ($map as $camel => $snake) {
+            if (array_key_exists($camel, $source) && ! array_key_exists($snake, $source)) {
+                $normalized[$snake] = $source[$camel];
+            }
+        }
+
+        return array_merge($source, $normalized);
+    }
+
+    // =========================
+    // 🔹 Rules Layer
+    // =========================
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function clientRules(): array
+    {
+        return [
+            'required',
+            'uuid',
+            Rule::exists('clients', 'id')
+                ->whereNull('deleted_at'),
+        ];
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function stockingRules(): array
+    {
+        return [
+            'required',
+            'uuid',
+            Rule::exists('stockings', 'id')
+                ->where(
+                    fn ($q) => $q
+                        ->whereNull('deleted_at')
+                ),
+        ];
+    }
+}

--- a/app/Presentation/Requests/SalesOrder/SalesOrderUpdateRequest.php
+++ b/app/Presentation/Requests/SalesOrder/SalesOrderUpdateRequest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Requests\SalesOrder;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Domain\Enums\SalesOrderType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class SalesOrderUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge(['id' => $this->route('id')]);
+
+        $this->merge(
+            array_merge(
+                $this->normalizeFields(),
+                $this->normalizeItems()
+            )
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $companyId = $this->companyId();
+
+        return [
+            'id' => [
+                'required',
+                'uuid',
+                Rule::exists('sales_orders', 'id')->where(static function ($q) use ($companyId): void {
+                    $q->where('company_id', $companyId)
+                        ->where('type', SalesOrderType::ORDER->value)
+                        ->whereNull('deleted_at');
+                }),
+            ],
+            'client_id'              => $this->clientRules(),
+            'issue_date'             => ['required', 'date_format:Y-m-d'],
+            'expected_payment_date'  => ['required', 'date_format:Y-m-d', 'after_or_equal:issue_date'],
+            'expected_delivery_date' => ['required', 'date_format:Y-m-d', 'after_or_equal:issue_date'],
+            'financial_category_id'  => ['required', 'uuid', 'exists:financial_categories,id'],
+            'needs_invoice'          => ['required', 'boolean'],
+            'notes'                  => ['nullable', 'string', 'max:65535'],
+            'items'                  => ['required', 'array', 'min:1'],
+            'items.*.stocking_id'    => $this->stockingRules(),
+            'items.*.quantity'       => ['required', 'numeric', 'gt:0'],
+            'items.*.unit_price'     => ['required', 'numeric', 'min:0'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeFields(): array
+    {
+        return $this->mapCamelToSnake([
+            'clientId'             => 'client_id',
+            'issueDate'            => 'issue_date',
+            'expectedPaymentDate'  => 'expected_payment_date',
+            'expectedDeliveryDate' => 'expected_delivery_date',
+            'needsInvoice'         => 'needs_invoice',
+            'financialCategoryId'  => 'financial_category_id',
+            'companyId'            => 'company_id',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeItems(): array
+    {
+        if (! $this->has('items') || ! is_array($this->input('items'))) {
+            return [];
+        }
+
+        return [
+            'items' => array_map(
+                fn (?array $item): array => $this->mapCamelToSnake([
+                    'stockingId' => 'stocking_id',
+                    'unitPrice'  => 'unit_price',
+                ], $item),
+                $this->input('items')
+            ),
+        ];
+    }
+
+    /**
+     * @param array<string, string> $map
+     * @param array<string, mixed>|null $source
+     *
+     * @return array<string, mixed>
+     */
+    private function mapCamelToSnake(array $map, ?array $source = null): array
+    {
+        $source ??= $this->all();
+        $normalized = [];
+
+        foreach ($map as $camel => $snake) {
+            if (array_key_exists($camel, $source) && ! array_key_exists($snake, $source)) {
+                $normalized[$snake] = $source[$camel];
+            }
+        }
+
+        return array_merge($source, $normalized);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function clientRules(): array
+    {
+        return [
+            'required',
+            'uuid',
+            Rule::exists('clients', 'id')
+                ->where('company_id', $this->companyId())
+                ->whereNull('deleted_at'),
+        ];
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function stockingRules(): array
+    {
+        return [
+            'required',
+            'uuid',
+            Rule::exists('stockings', 'id')
+                ->where(fn ($q) => $q->whereNull('deleted_at')),
+        ];
+    }
+
+    private function companyId(): ?string
+    {
+        $hint = $this->input('company_id');
+
+        if (! is_string($hint) || $hint === '') {
+            $camel = $this->input('companyId');
+            $hint  = (is_string($camel) && $camel !== '') ? $camel : null;
+        }
+
+        return app(CompanyResolverInterface::class)->tryResolve($hint);
+    }
+}

--- a/app/Presentation/Requests/SalesOrder/SalesQuotationStoreRequest.php
+++ b/app/Presentation/Requests/SalesOrder/SalesQuotationStoreRequest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Requests\SalesOrder;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class SalesQuotationStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $map = [
+            'clientId'       => 'client_id',
+            'issueDate'      => 'issue_date',
+            'expirationDate' => 'expiration_date',
+        ];
+
+        $normalized = [];
+
+        foreach ($map as $camel => $snake) {
+            if ($this->has($camel) && ! $this->has($snake)) {
+                $normalized[$snake] = $this->input($camel);
+            }
+        }
+
+        if ($this->has('items') && is_array($this->input('items'))) {
+            $normalized['items'] = array_map(
+                static function (mixed $row): array {
+                    if (! is_array($row)) {
+                        return [];
+                    }
+
+                    $item = [];
+
+                    if (isset($row['stockingId']) && ! isset($row['stocking_id'])) {
+                        $item['stocking_id'] = $row['stockingId'];
+                    }
+
+                    if (isset($row['unitPrice']) && ! isset($row['unit_price'])) {
+                        $item['unit_price'] = $row['unitPrice'];
+                    }
+
+                    if (isset($row['measureUnit']) && ! isset($row['measure_unit'])) {
+                        $item['measure_unit'] = $row['measureUnit'];
+                    }
+
+                    if (! isset($row['measure_unit'], $item['measure_unit']) && ! isset($row['measureUnit'])) {
+                        $item['measure_unit'] = 'kg';
+                    }
+
+                    return array_merge($row, $item);
+                },
+                $this->input('items'),
+            );
+        }
+
+        if ($normalized !== []) {
+            $this->merge($normalized);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $companyId = $this->companyId();
+
+        $clientRules = [
+            'required',
+            'uuid',
+        ];
+
+        if ($companyId !== null) {
+            $clientRules[] = Rule::exists('clients', 'id')
+                ->where('company_id', $companyId)
+                ->whereNull('deleted_at');
+        } else {
+            $clientRules[] = static function (string $attribute, mixed $value, \Closure $fail): void {
+                $fail('Unable to resolve the authenticated user\'s company.');
+            };
+        }
+
+        $stockingRules = [
+            'required',
+            'uuid',
+        ];
+
+        if ($companyId !== null) {
+            $stockingRules[] = Rule::exists('stockings', 'id')->where(static function ($query) use ($companyId): void {
+                $query->whereNull('deleted_at')
+                    ->whereIn('batch_id', static function ($sub) use ($companyId): void {
+                        $sub->select('id')
+                            ->from('batches')
+                            ->whereNull('deleted_at')
+                            ->whereIn('tank_id', static function ($tankSub) use ($companyId): void {
+                                $tankSub->select('id')
+                                    ->from('tanks')
+                                    ->where('company_id', $companyId)
+                                    ->whereNull('deleted_at');
+                            });
+                    });
+            });
+        } else {
+            $stockingRules[] = static function (string $attribute, mixed $value, \Closure $fail): void {
+                $fail('Unable to resolve the authenticated user\'s company.');
+            };
+        }
+
+        return [
+            'client_id'       => $clientRules,
+            'issue_date'      => ['required', 'date_format:Y-m-d'],
+            'expiration_date' => ['required', 'date_format:Y-m-d', 'after_or_equal:issue_date'],
+            'notes'           => ['nullable', 'string', 'max:65535'],
+
+            'items'                => ['required', 'array', 'min:1'],
+            'items.*.stocking_id'  => $stockingRules,
+            'items.*.quantity'     => ['required', 'numeric', 'gt:0'],
+            'items.*.unit_price'   => ['required', 'numeric', 'min:0'],
+            'items.*.measure_unit' => ['sometimes', 'string', 'in:kg,g,un'],
+        ];
+    }
+
+    #[\Override]
+    public function messages(): array
+    {
+        return [
+            'client_id.required'             => 'The client is required.',
+            'client_id.exists'               => 'The client does not exist or does not belong to the company.',
+            'issue_date.required'            => 'The issue date is required.',
+            'issue_date.date_format'         => 'The issue date must be in Y-m-d format.',
+            'expiration_date.required'       => 'The expiration date is required.',
+            'expiration_date.after_or_equal' => 'The expiration date must be equal or greater than the issue date.',
+            'items.required'                 => 'The quotation must have at least one item.',
+            'items.*.stocking_id.required'   => 'The stocking of the item is required.',
+            'items.*.stocking_id.exists'     => 'The stocking does not exist or does not belong to this company.',
+            'items.*.quantity.gt'            => 'The quantity of the item must be greater than zero.',
+            'items.*.unit_price.min'         => 'The unit price cannot be negative.',
+            'items.*.measure_unit.in'        => 'The measure unit must be: kg, g or un.',
+        ];
+    }
+
+    private function companyId(): ?string
+    {
+        $hint = $this->input('company_id');
+
+        if (! is_string($hint) || $hint === '') {
+            $camel = $this->input('companyId');
+            $hint  = (is_string($camel) && $camel !== '') ? $camel : null;
+        }
+
+        return app(CompanyResolverInterface::class)->tryResolve($hint);
+    }
+}

--- a/app/Presentation/Requests/SalesOrder/SalesQuotationUpdateRequest.php
+++ b/app/Presentation/Requests/SalesOrder/SalesQuotationUpdateRequest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Requests\SalesOrder;
+
+use App\Application\Contracts\CompanyResolverInterface;
+use App\Domain\Enums\SalesOrderType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class SalesQuotationUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    protected function prepareForValidation(): void
+    {
+        $this->merge(
+            [
+            'id' => $this->route('id'),
+            ]
+        );
+
+        $map = [
+            'clientId'       => 'client_id',
+            'issueDate'      => 'issue_date',
+            'expirationDate' => 'expiration_date',
+        ];
+
+        $normalized = [];
+
+        foreach ($map as $camel => $snake) {
+            if ($this->has($camel) && ! $this->has($snake)) {
+                $normalized[$snake] = $this->input($camel);
+            }
+        }
+
+        if ($this->has('items') && is_array($this->input('items'))) {
+            $normalized['items'] = array_map(
+                static function (mixed $row): array {
+                    if (! is_array($row)) {
+                        return [];
+                    }
+
+                    $item = [];
+
+                    if (isset($row['stockingId']) && ! isset($row['stocking_id'])) {
+                        $item['stocking_id'] = $row['stockingId'];
+                    }
+
+                    if (isset($row['unitPrice']) && ! isset($row['unit_price'])) {
+                        $item['unit_price'] = $row['unitPrice'];
+                    }
+
+                    if (isset($row['measureUnit']) && ! isset($row['measure_unit'])) {
+                        $item['measure_unit'] = $row['measureUnit'];
+                    }
+
+                    if (! isset($row['measure_unit'], $item['measure_unit']) && ! isset($row['measureUnit'])) {
+                        $item['measure_unit'] = 'kg';
+                    }
+
+                    return array_merge($row, $item);
+                },
+                $this->input('items'),
+            );
+        }
+
+        if ($normalized !== []) {
+            $this->merge($normalized);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $companyId = $this->companyId();
+
+        $idRules = ['required', 'uuid'];
+
+        if ($companyId !== null) {
+            $idRules[] = Rule::exists('sales_orders', 'id')->where(
+                static function ($query) use ($companyId): void {
+                    $query->where('company_id', $companyId)
+                        ->where('type', SalesOrderType::QUOTATION->value)
+                        ->whereNull('deleted_at');
+                }
+            );
+        } else {
+            $idRules[] = static function (string $attribute, mixed $value, \Closure $fail): void {
+                $fail('Unable to resolve the authenticated user\'s company.');
+            };
+        }
+
+        $clientRules = ['required', 'uuid'];
+
+        if ($companyId !== null) {
+            $clientRules[] = Rule::exists('clients', 'id')
+                ->where('company_id', $companyId)
+                ->whereNull('deleted_at');
+        } else {
+            $clientRules[] = static function (string $attribute, mixed $value, \Closure $fail): void {
+                $fail('Unable to resolve the authenticated user\'s company.');
+            };
+        }
+
+        $stockingRules = ['required', 'uuid'];
+
+        if ($companyId !== null) {
+            $stockingRules[] = Rule::exists('stockings', 'id')->where(
+                static function ($query) use ($companyId): void {
+                    $query->whereNull('deleted_at')
+                        ->whereIn(
+                            'batch_id',
+                            static function ($sub) use ($companyId): void {
+                                $sub->select('id')
+                                    ->from('batches')
+                                    ->whereNull('deleted_at')
+                                    ->whereIn(
+                                        'tank_id',
+                                        static function ($tankSub) use ($companyId): void {
+                                            $tankSub->select('id')
+                                                ->from('tanks')
+                                                ->where('company_id', $companyId)
+                                                ->whereNull('deleted_at');
+                                        }
+                                    );
+                            }
+                        );
+                }
+            );
+        } else {
+            $stockingRules[] = static function (string $attribute, mixed $value, \Closure $fail): void {
+                $fail('Unable to resolve the authenticated user\'s company.');
+            };
+        }
+
+        return [
+            'id'              => $idRules,
+            'client_id'       => $clientRules,
+            'issue_date'      => ['required', 'date_format:Y-m-d'],
+            'expiration_date' => ['required', 'date_format:Y-m-d', 'after_or_equal:issue_date'],
+            'notes'           => ['nullable', 'string', 'max:65535'],
+
+            'items'                => ['required', 'array', 'min:1'],
+            'items.*.stocking_id'  => $stockingRules,
+            'items.*.quantity'     => ['required', 'numeric', 'gt:0'],
+            'items.*.unit_price'   => ['required', 'numeric', 'min:0'],
+            'items.*.measure_unit' => ['sometimes', 'string', 'in:kg,g,un'],
+        ];
+    }
+
+    #[\Override]
+    public function messages(): array
+    {
+        return [
+            'id.required'                    => 'The quotation id is required.',
+            'id.exists'                      =>
+                'The quotation does not exist, is not active for this company, or was removed.',
+            'client_id.required'             => 'The client is required.',
+            'client_id.exists'               => 'The client does not exist or does not belong to the company.',
+            'issue_date.required'            => 'The issue date is required.',
+            'issue_date.date_format'         => 'The issue date must be in Y-m-d format.',
+            'expiration_date.required'       => 'The expiration date is required.',
+            'expiration_date.after_or_equal' => 'The expiration date must be equal or greater than the issue date.',
+            'items.required'                 => 'The quotation must have at least one item.',
+            'items.*.stocking_id.required'   => 'The stocking of the item is required.',
+            'items.*.stocking_id.exists'     => 'The stocking does not exist or does not belong to this company.',
+            'items.*.quantity.gt'            => 'The quantity of the item must be greater than zero.',
+            'items.*.unit_price.min'         => 'The unit price cannot be negative.',
+            'items.*.measure_unit.in'        => 'The measure unit must be: kg, g or un.',
+        ];
+    }
+
+    private function companyId(): ?string
+    {
+        $hint = $this->input('company_id');
+
+        if (! is_string($hint) || $hint === '') {
+            $camel = $this->input('companyId');
+            $hint  = (is_string($camel) && $camel !== '') ? $camel : null;
+        }
+
+        return app(CompanyResolverInterface::class)->tryResolve($hint);
+    }
+}

--- a/app/Presentation/Resources/SalesOrder/SalesOrderItemResource.php
+++ b/app/Presentation/Resources/SalesOrder/SalesOrderItemResource.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Resources\SalesOrder;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Domain\Models\SalesOrderItem
+ */
+final class SalesOrderItemResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'          => $this->id,
+            'quantity'    => (float) $this->quantity,
+            'unitPrice'   => (float) $this->unit_price,
+            'subtotal'    => (float) $this->subtotal,
+            'measureUnit' => $this->measure_unit,
+            'stocking'    => $this->whenLoaded('stocking', fn (): array => [
+                'id'                   => $this->stocking->id,
+                'quantity'             => $this->stocking->quantity,
+                'averageWeight'        => $this->stocking->average_weight,
+                'estimatedBiomass'     => $this->stocking->estimated_biomass,
+                'accumulatedFixedCost' => $this->stocking->accumulated_fixed_cost,
+            ]),
+            'createdAt' => $this->created_at?->toDateTimeString(),
+            'updatedAt' => $this->updated_at?->toDateTimeString(),
+        ];
+    }
+}

--- a/app/Presentation/Resources/SalesOrder/SalesOrderResource.php
+++ b/app/Presentation/Resources/SalesOrder/SalesOrderResource.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Presentation\Resources\SalesOrder;
+
+use App\Domain\Enums\SalesOrderStatus;
+use App\Domain\Enums\SalesOrderType;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Domain\Models\SalesOrder
+ */
+final class SalesOrderResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function toArray(Request $request): array
+    {
+        /** @var SalesOrderType $type */
+        $type = $this->type;
+        /** @var SalesOrderStatus $status */
+        $status = $this->status;
+
+        return [
+            'id'             => $this->id,
+            'companyId'      => $this->company_id,
+            'clientId'       => $this->client_id,
+            'type'           => $type->value,
+            'status'         => $status->value,
+            'statusLabel'    => $status->label(),
+            'totalAmount'    => (float) $this->total_amount,
+            'issueDate'      => $this->issue_date->toDateString(),
+            'expirationDate' => $this->expiration_date?->toDateString(),
+            'quotationId'    => $this->quotation_id,
+            'notes'          => $this->notes,
+
+            'company' => $this->whenLoaded('company', fn (): array => [
+                'id'   => $this->company->id,
+                'name' => $this->company->name,
+            ]),
+
+            'client' => $this->whenLoaded('client', fn (): array => [
+                'id'   => $this->client->id,
+                'name' => $this->client->name,
+            ]),
+
+            'items' => $this->when(
+                $this->relationLoaded('items'),
+                fn () => SalesOrderItemResource::collection($this->items),
+            ),
+
+            'createdAt' => $this->created_at?->toDateTimeString(),
+            'updatedAt' => $this->updated_at?->toDateTimeString(),
+        ];
+    }
+}

--- a/database/migrations/2026_04_11_100000_create_sales_orders_and_sales_order_items_tables.php
+++ b/database/migrations/2026_04_11_100000_create_sales_orders_and_sales_order_items_tables.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sales_orders', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('company_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('client_id')->constrained('clients')->cascadeOnDelete();
+
+            $table->enum('type', ['quotation', 'order'])->default('quotation');
+
+            $table->string('status')->default('draft');
+
+            $table->decimal('total_amount', 15, 2)->default(0);
+            $table->date('issue_date');
+            $table->date('expiration_date')->nullable();
+
+            $table->foreignUuid('quotation_id')->nullable()->constrained('sales_orders')->nullOnDelete();
+
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['company_id', 'type', 'status']);
+        });
+
+        Schema::create('sales_order_items', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('sales_order_id')->constrained('sales_orders')->cascadeOnDelete();
+            $table->foreignUuid('stocking_id')->constrained('stockings');
+
+            $table->decimal('quantity', 12, 3);
+            $table->decimal('unit_price', 15, 2);
+            $table->decimal('subtotal', 15, 2);
+
+            $table->string('measure_unit')->default('kg');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sales_order_items');
+        Schema::dropIfExists('sales_orders');
+    }
+};

--- a/database/migrations/2026_04_11_110000_add_sales_order_permissions.php
+++ b/database/migrations/2026_04_11_110000_add_sales_order_permissions.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class () extends Migration
+{
+    private const array PERMISSION_NAMES = [
+        'create-sales-order',
+        'view-sales-order',
+        'update-sales-order',
+        'delete-sales-order',
+        'cancel-sale-order',
+    ];
+
+    public function up(): void
+    {
+        $now = now();
+
+        $permissionIds = [];
+
+        foreach (self::PERMISSION_NAMES as $name) {
+            $existing = DB::table('permissions')->where('name', $name)->first();
+
+            if ($existing !== null) {
+                $permissionIds[] = $existing->id;
+
+                continue;
+            }
+
+            $id = (string) Str::uuid();
+            DB::table('permissions')->insert([
+                'id'         => $id,
+                'name'       => $name,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+            $permissionIds[] = $id;
+        }
+
+        $roleId = DB::table('roles')->where('name', 'company-admin')->value('id');
+
+        if ($roleId === null) {
+            return;
+        }
+
+        foreach ($permissionIds as $permissionId) {
+            $exists = DB::table('permission_role')
+                ->where('role_id', $roleId)
+                ->where('permission_id', $permissionId)
+                ->exists();
+
+            if (! $exists) {
+                DB::table('permission_role')->insert([
+                    'permission_id' => $permissionId,
+                    'role_id'       => $roleId,
+                ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        $roleId = DB::table('roles')->where('name', 'company-admin')->value('id');
+
+        $permissionIds = DB::table('permissions')
+            ->whereIn('name', self::PERMISSION_NAMES)
+            ->pluck('id');
+
+        if ($roleId !== null && $permissionIds->isNotEmpty()) {
+            DB::table('permission_role')
+                ->where('role_id', $roleId)
+                ->whereIn('permission_id', $permissionIds)
+                ->delete();
+        }
+
+        DB::table('permissions')->whereIn('name', self::PERMISSION_NAMES)->delete();
+    }
+};

--- a/database/migrations/2026_04_14_120000_add_delivery_dates_to_sales_orders_table.php
+++ b/database/migrations/2026_04_14_120000_add_delivery_dates_to_sales_orders_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sales_orders', function (Blueprint $table): void {
+            if (! Schema::hasColumn('sales_orders', 'expected_delivery_date')) {
+                $table->date('expected_delivery_date')->nullable()->after('issue_date');
+            }
+
+            if (! Schema::hasColumn('sales_orders', 'delivered_at')) {
+                $table->timestamp('delivered_at')->nullable()->after('expected_delivery_date');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sales_orders', function (Blueprint $table): void {
+            $columnsToDrop = array_values(array_filter([
+                Schema::hasColumn('sales_orders', 'delivered_at') ? 'delivered_at' : null,
+                Schema::hasColumn('sales_orders', 'expected_delivery_date') ? 'expected_delivery_date' : null,
+            ]));
+
+            if ($columnsToDrop !== []) {
+                $table->dropColumn($columnsToDrop);
+            }
+        });
+    }
+};

--- a/database/migrations/2026_04_14_130000_change_sales_orders_status_to_enum.php
+++ b/database/migrations/2026_04_14_130000_change_sales_orders_status_to_enum.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    /**
+     * @var list<string>
+     */
+    private const array STATUS_VALUES = [
+        'draft',
+        'open',
+        'sent',
+        'expired',
+        'paid',
+        'approved',
+        'confirmed',
+        'cancelled',
+        'finished',
+    ];
+
+    public function up(): void
+    {
+        if (! Schema::hasColumn('sales_orders', 'status')) {
+            return;
+        }
+
+        DB::table('sales_orders')
+            ->whereNotIn('status', self::STATUS_VALUES)
+            ->update(['status' => 'draft']);
+
+        $allowed = implode("','", self::STATUS_VALUES);
+
+        DB::statement(
+            "ALTER TABLE `sales_orders` MODIFY COLUMN `status` ENUM('{$allowed}') NOT NULL DEFAULT 'draft'"
+        );
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('sales_orders', 'status')) {
+            return;
+        }
+
+        Schema::table('sales_orders', function (Blueprint $table): void {
+            $table->string('status')->default('draft')->change();
+        });
+    }
+};

--- a/database/migrations/2026_04_15_100000_add_sales_order_id_to_sales_table.php
+++ b/database/migrations/2026_04_15_100000_add_sales_order_id_to_sales_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sales', function (Blueprint $table): void {
+            if (! Schema::hasColumn('sales', 'sales_order_id')) {
+                $table->foreignUuid('sales_order_id')
+                    ->nullable()
+                    ->after('id')
+                    ->constrained('sales_orders')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sales', function (Blueprint $table): void {
+            if (Schema::hasColumn('sales', 'sales_order_id')) {
+                $table->dropForeign(['sales_order_id']);
+                $table->dropColumn('sales_order_id');
+            }
+        });
+    }
+};

--- a/database/seeders/CompanyAdminPermissionsSeeder.php
+++ b/database/seeders/CompanyAdminPermissionsSeeder.php
@@ -130,6 +130,12 @@ class CompanyAdminPermissionsSeeder extends Seeder
             'update-sale',
             'delete-sale',
 
+            // Pedidos / orçamentos (sales_orders)
+            'create-sales-order',
+            'view-sales-order',
+            'update-sales-order',
+            'delete-sales-order',
+
             // Permissões de Sensor
             'create-sensor',
             'view-sensor',

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,6 +64,8 @@ Route::prefix('company')
 
         require base_path('routes/app/company/sale.php');
 
+        require base_path('routes/app/company/salesOrder.php');
+
         require base_path('routes/app/company/sensor.php');
 
         require base_path('routes/app/company/sensorReading.php');

--- a/routes/app/company/salesOrder.php
+++ b/routes/app/company/salesOrder.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Presentation\Controllers\SalesOrderController;
+use App\Presentation\Controllers\SalesQuotationController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['permission:view-sale-order'])
+    ->get('sale-orders', [SalesOrderController::class, 'index']);
+
+Route::middleware(['permission:view-sale-order'])
+    ->get('sale-orders/quotations', [SalesQuotationController::class, 'index']);
+
+Route::middleware(['permission:view-sale-order'])
+    ->get('sale-order/{id}', [SalesOrderController::class, 'show']);
+
+Route::middleware(['permission:view-sale-order'])
+    ->get('sale-order/quotation/{id}', [SalesQuotationController::class, 'show']);
+
+Route::middleware(['permission:create-sale-order'])
+    ->post('sale-order/quotation', [SalesQuotationController::class, 'store']);
+
+Route::middleware(['permission:create-sale-order'])
+    ->post('sale-order', [SalesOrderController::class, 'store']);
+
+Route::middleware(['permission:update-sale-order'])
+    ->put('sale-order/{id}', [SalesOrderController::class, 'update']);
+
+Route::middleware(['permission:update-sale-order'])
+    ->post('sale-order/quotation/{id}/convert', [SalesQuotationController::class, 'convert']);
+
+Route::middleware(['permission:update-sale-order'])
+    ->put('sale-order/quotation/{id}', [SalesQuotationController::class, 'update']);
+
+Route::middleware(['permission:delete-sale-order'])
+    ->delete('sale-order/{id}', [SalesOrderController::class, 'destroy']);
+
+Route::middleware(['permission:cancel-sale-order'])
+    ->delete('sale-order/{id}/cancel', [SalesOrderController::class, 'cancel']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -6132,6 +6132,612 @@
                 ]
             }
         },
+        "/company/sales-orders": {
+            "get": {
+                "tags": [
+                    "Sales orders"
+                ],
+                "summary": "Lista pedidos/orçamentos da empresa",
+                "operationId": "4a89c41b726c2c083bdd54f2cf8d6873",
+                "parameters": [
+                    {
+                        "name": "clientId",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "quotation",
+                                "order"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "perPage",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 25
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista paginada"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/company/sales-order/{id}": {
+            "get": {
+                "tags": [
+                    "Sales orders"
+                ],
+                "summary": "Detalhe de um pedido/orçamento",
+                "operationId": "114bf49b955490643b0b81f9c667f873",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Encontrado"
+                    },
+                    "404": {
+                        "description": "Não encontrado"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Sales orders"
+                ],
+                "summary": "Remove (soft delete) pedido/orçamento em rascunho ou aberto",
+                "operationId": "1cfc529a63d788159caca5189fae7b22",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Removido"
+                    },
+                    "404": {
+                        "description": "Não encontrado"
+                    },
+                    "422": {
+                        "description": "Status não permite exclusão"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/company/sale-order": {
+            "post": {
+                "tags": [
+                    "Sales orders"
+                ],
+                "summary": "Cria um pedido (order) com itens",
+                "operationId": "d7eec4111dee13943851170f293589c0",
+                "responses": {
+                    "201": {
+                        "description": "Pedido criado"
+                    },
+                    "422": {
+                        "description": "Erro de validação"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/company/sale-order/{id}": {
+            "put": {
+                "tags": [
+                    "Sales orders"
+                ],
+                "summary": "Atualiza um pedido (order) com regras de validação do create",
+                "operationId": "12216564a2b7aba9f766517c89a751cf",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Pedido atualizado"
+                    },
+                    "422": {
+                        "description": "Erro de validação"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/company/sales-order/{id}/cancel": {
+            "delete": {
+                "tags": [
+                    "Sales orders"
+                ],
+                "summary": "Cancela um pedido (order)",
+                "operationId": "7833f5e80e031cf5a247af4d55c89d2f",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Pedido cancelado"
+                    },
+                    "404": {
+                        "description": "Não encontrado"
+                    },
+                    "422": {
+                        "description": "Status não permite cancelamento"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/company/sale-orders/quotations": {
+            "get": {
+                "tags": [
+                    "Sales quotations"
+                ],
+                "summary": "Lista orçamentos (cotações) da empresa",
+                "operationId": "34979469914988b89307cc8b31870594",
+                "parameters": [
+                    {
+                        "name": "clientId",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "perPage",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 25
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista paginada"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/company/sale-order/quotation/{id}": {
+            "get": {
+                "tags": [
+                    "Sales quotations"
+                ],
+                "summary": "Detalhe de um orçamento (cotação)",
+                "operationId": "46fc40c96b1a1083766714baacfb1a26",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Encontrado"
+                    },
+                    "404": {
+                        "description": "Não encontrado"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/company/sale-order/quotation": {
+            "post": {
+                "tags": [
+                    "Sales quotations"
+                ],
+                "summary": "Cria um orçamento (cotação) com itens",
+                "operationId": "a643ee3e23d7752ffe13dbf916bd528d",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "clientId",
+                                    "issueDate",
+                                    "expirationDate",
+                                    "items"
+                                ],
+                                "properties": {
+                                    "companyId": {
+                                        "type": "string",
+                                        "format": "uuid",
+                                        "nullable": true
+                                    },
+                                    "clientId": {
+                                        "type": "string",
+                                        "format": "uuid"
+                                    },
+                                    "issueDate": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "expirationDate": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "notes": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "items": {
+                                        "type": "array",
+                                        "items": {
+                                            "required": [
+                                                "stockingId",
+                                                "quantity",
+                                                "unitPrice"
+                                            ],
+                                            "properties": {
+                                                "stockingId": {
+                                                    "type": "string",
+                                                    "format": "uuid"
+                                                },
+                                                "quantity": {
+                                                    "type": "number",
+                                                    "example": 100.5
+                                                },
+                                                "unitPrice": {
+                                                    "type": "number",
+                                                    "example": 18.9
+                                                },
+                                                "measureUnit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "kg",
+                                                        "g",
+                                                        "un"
+                                                    ],
+                                                    "nullable": true
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Orçamento criado"
+                    },
+                    "422": {
+                        "description": "Erro de validação"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/company/sale-order/quotation/{id}": {
+            "put": {
+                "tags": [
+                    "Sales quotations"
+                ],
+                "summary": "Atualiza um orçamento",
+                "operationId": "28b6361795f92f232c967a567bfa21d2",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "clientId": {
+                                        "type": "string",
+                                        "format": "uuid"
+                                    },
+                                    "issueDate": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "expirationDate": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "notes": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "items": {
+                                        "description": "Quando enviado, substitui TODOS os itens existentes.",
+                                        "type": "array",
+                                        "items": {
+                                            "required": [
+                                                "stockingId",
+                                                "quantity",
+                                                "unitPrice"
+                                            ],
+                                            "properties": {
+                                                "stockingId": {
+                                                    "type": "string",
+                                                    "format": "uuid"
+                                                },
+                                                "quantity": {
+                                                    "type": "number"
+                                                },
+                                                "unitPrice": {
+                                                    "type": "number"
+                                                },
+                                                "measureUnit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "kg",
+                                                        "g",
+                                                        "un"
+                                                    ],
+                                                    "nullable": true
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Orçamento atualizado"
+                    },
+                    "404": {
+                        "description": "Não encontrado"
+                    },
+                    "422": {
+                        "description": "Erro de validação"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/company/sale-order/quotation/{id}/convert": {
+            "post": {
+                "tags": [
+                    "Sales quotations"
+                ],
+                "summary": "Converte um orçamento em pedido (vendas, baixa de biomassa, contas a receber)",
+                "operationId": "cfd3278967a37d5495032a7cf4b1e02a",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "expectedDeliveryDate",
+                                    "expectedPaymentDate",
+                                    "financialCategoryId",
+                                    "needsInvoice"
+                                ],
+                                "properties": {
+                                    "expectedDeliveryDate": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "expectedPaymentDate": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "financialCategoryId": {
+                                        "type": "string",
+                                        "format": "uuid"
+                                    },
+                                    "needsInvoice": {
+                                        "type": "boolean"
+                                    },
+                                    "notes": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Pedido gerado a partir do orçamento"
+                    },
+                    "422": {
+                        "description": "Erro de validação"
+                    },
+                    "401": {
+                        "description": "Não autorizado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "/company/sensors": {
             "get": {
                 "tags": [
@@ -12741,6 +13347,14 @@
         {
             "name": "Sales",
             "description": "Vendas"
+        },
+        {
+            "name": "Sales orders",
+            "description": "Pedidos"
+        },
+        {
+            "name": "Sales quotations",
+            "description": "Orçamentos (cotações)"
         },
         {
             "name": "Sensors",


### PR DESCRIPTION
Implementa o fluxo completo de Sales Order e Sales Quotation, incluindo
entidades, DTOs, use cases, repositórios, controllers, requests e resources.

- Cria conversão de cotação para pedido e regras de status/cancelamento.
- Adiciona migrations, permissões e rotas de sales order.
- Integra ajustes no fluxo financeiro (receivable/payable) e cancelamento de venda.
- Atualiza tratamento de exceções e documentação OpenAPI.